### PR TITLE
remove new status from DownloadFile. Ready by default

### DIFF
--- a/app/models/download_file.rb
+++ b/app/models/download_file.rb
@@ -5,7 +5,7 @@ class DownloadFile < ApplicationDiskRecord
 
   ATTRIBUTES = %w[id collection_id type metadata_id external_id filename status size checksum content_type].freeze
   TYPES = %w[dataverse].freeze
-  STATUS = %w[new ready downloading success error].freeze
+  STATUS = %w[ready downloading success error].freeze
 
   attr_accessor *ATTRIBUTES
 
@@ -29,7 +29,7 @@ class DownloadFile < ApplicationDiskRecord
       f.metadata_id = download_collection.metadata_id
       f.external_id = dataset_file.data_file.id
       f.filename = dataset_file.data_file.filename
-      f.status = 'new'
+      f.status = 'ready'
       f.size = dataset_file.data_file.filesize
       f.checksum = dataset_file.data_file.md5
       f.content_type = dataset_file.data_file.content_type

--- a/test/models/download_collection_test.rb
+++ b/test/models/download_collection_test.rb
@@ -27,7 +27,7 @@ class DownloadCollectionTest < ActiveSupport::TestCase
     @file_attributes = {
       'id' => '123-321', 'collection_id' => '456-789', 'type' => 'dataverse',
       'metadata_id' => '123-456', 'external_id' => '789', 'filename' => 'test.png',
-      'status' => 'new', 'size' => 1024, 'checksum' => 'abc123', 'content_type' => 'image/png'
+      'status' => 'ready', 'size' => 1024, 'checksum' => 'abc123', 'content_type' => 'image/png'
     }
     @download_file = DownloadFile.new(@file_attributes)
     @file_filename = File.join(@tmp_dir, 'downloads', '456-789', 'files', '123-321.yml')
@@ -35,7 +35,7 @@ class DownloadCollectionTest < ActiveSupport::TestCase
     @file_attributes2 = {
       'id' => '111-123', 'collection_id' => '456-789', 'type' => 'dataverse',
       'metadata_id' => '123-456', 'external_id' => '790', 'filename' => 'test.png',
-      'status' => 'new', 'size' => 1024, 'checksum' => 'abc123', 'content_type' => 'image/png'
+      'status' => 'ready', 'size' => 1024, 'checksum' => 'abc123', 'content_type' => 'image/png'
     }
     @download_file2 = DownloadFile.new(@file_attributes2)
     @file_filename2 = File.join(@tmp_dir, 'downloads', '456-789', 'files', '111-123.yml')
@@ -43,7 +43,7 @@ class DownloadCollectionTest < ActiveSupport::TestCase
     @file_attributes3 = {
       'id' => '123-456', 'collection_id' => '111-111', 'type' => 'dataverse',
       'metadata_id' => '123-456', 'external_id' => '791', 'filename' => 'test.png',
-      'status' => 'new', 'size' => 1024, 'checksum' => 'abc123', 'content_type' => 'image/png'
+      'status' => 'ready', 'size' => 1024, 'checksum' => 'abc123', 'content_type' => 'image/png'
     }
     @download_file3 = DownloadFile.new(@file_attributes3)
     @file_filename3 = File.join(@tmp_dir, 'downloads', '111-111', 'files', '123-456.yml')
@@ -230,7 +230,7 @@ class DownloadCollectionTest < ActiveSupport::TestCase
     assert_equal '123-456', first_file.metadata_id
     assert_equal '789', first_file.external_id
     assert_equal 'test.png', first_file.filename
-    assert_equal 'new', first_file.status
+    assert_equal 'ready', first_file.status
     assert_equal 1024, first_file.size
     assert_equal 'abc123', first_file.checksum
   end

--- a/test/models/download_file_test.rb
+++ b/test/models/download_file_test.rb
@@ -8,7 +8,7 @@ class DownloadFileTest < ActiveSupport::TestCase
     @valid_attributes = {
       'id' => '123-321', 'collection_id' => '456-789', 'type' => 'dataverse',
       'metadata_id' => '123-456', 'external_id' => '789', 'filename' => 'test.png',
-      'status' => 'new', 'size' => 1024, 'checksum' => 'abc123', 'content_type' => 'image/png'
+      'status' => 'ready', 'size' => 1024, 'checksum' => 'abc123', 'content_type' => 'image/png'
     }
     @download_file = DownloadFile.new(@valid_attributes)
     @test_filename = File.join(@tmp_dir, 'downloads', '456-789', 'files', '123-321.yml')
@@ -25,7 +25,7 @@ class DownloadFileTest < ActiveSupport::TestCase
     assert_equal '123-456', @download_file.metadata_id
     assert_equal '789', @download_file.external_id
     assert_equal 'test.png', @download_file.filename
-    assert_equal 'new', @download_file.status
+    assert_equal 'ready', @download_file.status
     assert_equal 1024, @download_file.size
     assert_equal 'abc123', @download_file.checksum
     assert_equal 'image/png', @download_file.content_type
@@ -118,7 +118,7 @@ class DownloadFileTest < ActiveSupport::TestCase
     assert_equal '123-456', loaded_file.metadata_id
     assert_equal '789', loaded_file.external_id
     assert_equal 'test.png', loaded_file.filename
-    assert_equal 'new', loaded_file.status
+    assert_equal 'ready', loaded_file.status
     assert_equal 1024, loaded_file.size
     assert_equal 'abc123', loaded_file.checksum
     assert_equal 'image/png', loaded_file.content_type
@@ -151,7 +151,7 @@ class DownloadFileTest < ActiveSupport::TestCase
     assert_equal 'dataverse', new_download_file.type
     assert_equal '123-456', new_download_file.metadata_id
     assert_equal 'screenshot.png', new_download_file.filename
-    assert_equal 'new', new_download_file.status
+    assert_equal 'ready', new_download_file.status
     assert_equal 272314, new_download_file.size
     assert_equal "13035cba04a51f54dd8101fe726cda5c", new_download_file.checksum
     assert_equal 'image/png', new_download_file.content_type


### PR DESCRIPTION
small PR to remove `new` status from DownloadFile class. The default initial status is `ready`