### PR TITLE
Fixed execution of download process 

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -35,6 +35,6 @@ logs:
 bash:
 	docker exec -it passenger_loop_ood /bin/bash
 
-test: clean
+test:
 	docker run --rm -v $(WORKING_DIR)/application:/usr/local/app -v $(WORKING_DIR)/scripts:/usr/local/scripts -w /usr/local/app $(LOOP_BUILDER_IMAGE) /usr/local/scripts/loop_test.sh
 

--- a/application/app/services/detach_process.rb
+++ b/application/app/services/detach_process.rb
@@ -3,8 +3,22 @@
 class DetachProcess
   SCRIPT = 'scripts/download_process.rb'
 
-  # TODO: We need a status page to show the detached service execution logs and possibly other things
   def start_process
+    ruby_binary = Configuration.ruby_binary
+    script_log_file = File.join(Configuration.metadata_root, 'download_service.log')
+    pid = Process.spawn(
+      ruby_binary,
+      DetachProcess::SCRIPT,
+      out: [script_log_file, 'a'],
+      err: [script_log_file, 'a'],
+      in: '/dev/null',
+      pgroup: true
+    )
+    Process.detach(pid)
+  end
+
+  # TODO: We need a status page to show the detached service execution logs and possibly other things
+  def start_process_bak
     script_log_file = File.join(Configuration.metadata_root, 'download_service.log')
     ruby_binary = Configuration.ruby_binary
     system("nohup #{ruby_binary} #{DetachProcess::SCRIPT} >> #{script_log_file} 2>&1 &")

--- a/application/app/services/download/download_files_provider.rb
+++ b/application/app/services/download/download_files_provider.rb
@@ -5,5 +5,9 @@ module Download
     def pending_files
       DownloadCollection.all.flat_map(&:files).select{|f| f.status == 'ready'}
     end
+
+    def processing_files
+      DownloadCollection.all.flat_map(&:files).select{|f| f.status == 'downloading'}
+    end
   end
 end

--- a/application/app/services/download/download_service.rb
+++ b/application/app/services/download/download_service.rb
@@ -31,7 +31,9 @@ module Download
     def process
       while true
         files = files_provider.pending_files
+        in_progress = files_provider.processing_files
         stats[:pending] = files.length
+        stats[:progress] = in_progress.length
 
         log_info('Processing', {pid: process_id, elapsed_time: elapsed_time, stats: stats_to_s})
         batch = files.first(1)
@@ -57,7 +59,7 @@ module Download
     end
 
     def stats_to_s
-      "pending=#{stats[:pending]} completed=#{stats[:completed]}"
+      "in_progress=#{stats[:progress]} pending=#{stats[:pending]} completed=#{stats[:completed]}"
     end
 
     def lock_file

--- a/application/test/utils/download_files_provider_mock.rb
+++ b/application/test/utils/download_files_provider_mock.rb
@@ -9,4 +9,8 @@ class DownloadFilesProviderMock
   def pending_files
     @files[@from..-1].tap { @from += 1 }
   end
+
+  def processing_files
+    []
+  end
 end


### PR DESCRIPTION
Fixed execution of download process so that it does not stop when parent stops in OOD.

I have to revert to the initial solution as the previous one does not work in the OOD environment.