### PR TITLE
handle Unauthorized endpoint exception

### DIFF
--- a/application/app/controllers/dataverse/datasets_controller.rb
+++ b/application/app/controllers/dataverse/datasets_controller.rb
@@ -46,6 +46,10 @@ class Dataverse::DatasetsController < ApplicationController
         redirect_to root_path
         return
       end
+    rescue Dataverse::DataverseService::UnauthorizedException => e
+      log_error('Dataset requires authorization', {dataverse: @dataverse_url, persistent_id: @persistent_id}, e)
+      flash[:error] = "Dataset requires authorization. Dataverse: #{@dataverse_url} persistentId: #{@persistent_id}"
+      redirect_to root_path
     rescue Exception => e
       log_error('Dataverse service error', {dataverse: @dataverse_url, persistent_id: @persistent_id}, e)
       flash[:error] = "Dataverse service error. Dataverse: #{@dataverse_url} persistentId: #{@persistent_id}"

--- a/application/app/controllers/dataverse/dataverses_controller.rb
+++ b/application/app/controllers/dataverse/dataverses_controller.rb
@@ -28,6 +28,10 @@ class Dataverse::DataversesController < ApplicationController
         redirect_to root_path
         return
       end
+    rescue Dataverse::DataverseService::UnauthorizedException => e
+      log_error('Dataverse requires authorization', {dataverse: @dataverse_url, id: params[:id]}, e)
+      flash[:error] = "Dataverse requires authorization. Dataverse: #{@dataverse_url} Id: #{params[:id]}"
+      redirect_to root_path
     rescue Exception => e
       log_error('Dataverse service error', {dataverse: @dataverse_url, id: params[:id]}, e)
       flash[:error] = "Dataverse service error. Dataverse: #{@dataverse_url} Id: #{params[:id]}"

--- a/application/app/services/dataverse/dataverse_service.rb
+++ b/application/app/services/dataverse/dataverse_service.rb
@@ -2,6 +2,8 @@ module Dataverse
   class DataverseService
     include LoggingCommon
 
+    class UnauthorizedException < Exception; end
+
     def initialize(dataverse_url)
       @dataverse_url = dataverse_url
     end
@@ -11,6 +13,7 @@ module Dataverse
       url = URI.parse(url)
       response = Net::HTTP.get_response(url)
       return nil if response.is_a?(Net::HTTPNotFound)
+      raise UnauthorizedException if response.is_a?(Net::HTTPUnauthorized)
       raise "Error getting dataset: #{response.code} - #{response.body}" unless response.is_a?(Net::HTTPSuccess)
       DatasetResponse.new(response.body)
     end
@@ -20,6 +23,7 @@ module Dataverse
       url = URI.parse(url)
       response = Net::HTTP.get_response(url)
       return nil if response.is_a?(Net::HTTPNotFound)
+      raise UnauthorizedException if response.is_a?(Net::HTTPUnauthorized)
       raise "Error getting dataset: #{response.code} - #{response.body}" unless response.is_a?(Net::HTTPSuccess)
       DatasetResponse.new(response.body)
     end
@@ -29,6 +33,7 @@ module Dataverse
       url = URI.parse(url)
       response = Net::HTTP.get_response(url)
       return nil if response.is_a?(Net::HTTPNotFound)
+      raise UnauthorizedException if response.is_a?(Net::HTTPUnauthorized)
       raise "Error getting dataverse: #{response.code} - #{response.body}" unless response.is_a?(Net::HTTPSuccess)
       DataverseResponse.new(response.body)
     end
@@ -40,6 +45,7 @@ module Dataverse
       url = URI.parse(url)
       response = Net::HTTP.get_response(url)
       return nil if response.is_a?(Net::HTTPNotFound)
+      raise UnauthorizedException if response.is_a?(Net::HTTPUnauthorized)
       raise "Error getting dataverse items: #{response.code} - #{response.body}" unless response.is_a?(Net::HTTPSuccess)
       SearchResponse.new(response.body, page, per_page)
     end

--- a/application/test/controllers/dataverse/datasets_controller_test.rb
+++ b/application/test/controllers/dataverse/datasets_controller_test.rb
@@ -52,6 +52,13 @@ class Dataverse::DatasetsControllerTest < ActionDispatch::IntegrationTest
     assert_equal "Dataverse service error. Dataverse: https://#{@new_id} persistentId: random_id", flash[:error]
   end
 
+  test "should redirect to root path after raising Unauthorized exception" do
+    Dataverse::DataverseService.any_instance.stubs(:find_dataset_by_persistent_id).raises(Dataverse::DataverseService::UnauthorizedException)
+    get view_dataverse_dataset_url(@new_id, "random_id")
+    assert_redirected_to root_path
+    assert_equal "Dataset requires authorization. Dataverse: https://#{@new_id} persistentId: random_id", flash[:error]
+  end
+
   test "should display the dataset view with the file" do
     dataset = Dataverse::DatasetResponse.new(valid_json_body)
     Dataverse::DataverseService.any_instance.stubs(:find_dataset_by_persistent_id).returns(dataset)

--- a/application/test/controllers/dataverse/dataverses_controller_test.rb
+++ b/application/test/controllers/dataverse/dataverses_controller_test.rb
@@ -17,6 +17,14 @@ class Dataverse::DataversesControllerTest < ActionDispatch::IntegrationTest
     assert_equal "Dataverse service error. Dataverse: https://example.com Id: :root", flash[:error]
   end
 
+  test "should redirect to root path after finding an unauthorized dataverse" do
+    Dataverse::DataverseService.any_instance.stubs(:find_dataverse_by_id).returns(nil)
+    Dataverse::DataverseService.any_instance.stubs(:search_dataverse_items).raises(Dataverse::DataverseService::UnauthorizedException)
+    get view_dataverse_url("example.com", ":root")
+    assert_redirected_to root_path
+    assert_equal "Dataverse requires authorization. Dataverse: https://example.com Id: :root", flash[:error]
+  end
+
   test "should redirect to root path after not finding neither dataverse nor dataverse results" do
     Dataverse::DataverseService.any_instance.stubs(:find_dataverse_by_id).returns(nil)
     Dataverse::DataverseService.any_instance.stubs(:search_dataverse_items).returns(nil)


### PR DESCRIPTION
It happens to be that the search endpoint used to display a dataverse content, in some installations requires authentication and doesn't allow access for public resources. In these scenarios, the endpoint returns a status code 401. In this PR we handle this restriction to redirect the user with a message