### PR TITLE
Fixed SSL cert issue with hub.dataverse.org

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -4,7 +4,7 @@ all:: loop_up
 COMPOSE_CMD = docker compose
 OOD_UID := $(shell id -u)
 OOD_GID := $(shell id -g)
-OOD_IMAGE := hmdc/sid-ood:ood-3.1.7.el8
+OOD_IMAGE := hmdc/sid-ood:ood-3.1.7.ssl.el8
 LOOP_BUILDER_IMAGE := hmdc/ondemand-loop:builder-R3.1
 WORKING_DIR := $(shell pwd)
 

--- a/application/app/services/common/http_client.rb
+++ b/application/app/services/common/http_client.rb
@@ -140,8 +140,6 @@ module Common
              end
 
       http.use_ssl = uri.scheme == "https"
-      # TODO remove this line after fixing container certificates to connect to hub.dataverse.org
-      http.verify_mode = OpenSSL::SSL::VERIFY_NONE if http.use_ssl? && uri.host == "hub.dataverse.org"
       http.open_timeout = @open_timeout
       http.read_timeout = @read_timeout
       http


### PR DESCRIPTION
The problems seems to be that `hub.dataverse.org ` SSL cert is not configured correctly and not returning the full chain of trusted certs. So we have to add the final certificate as a trusted one in the container.

I created a new version of our container with these certs and uploaded it to DockerHub:
`hmdc/sid-ood:ood-3.1.7.ssl.el8`