### PR TITLE
Create dataset service

### DIFF
--- a/application/app/models/dataverse/create_dataset_request.rb
+++ b/application/app/models/dataverse/create_dataset_request.rb
@@ -1,0 +1,90 @@
+module Dataverse
+  class CreateDatasetRequest
+    attr_accessor :title, :description, :author, :contact_email, :subjects
+
+    def initialize(title:, description:, author:, contact_email:, subjects:)
+      @title = title
+      @description = description
+      @author = author
+      @contact_email = contact_email
+      @subjects = subjects
+    end
+
+    def to_json
+      {
+        datasetVersion: {
+          metadataBlocks: {
+            citation: {
+              fields: [
+                {
+                  value: title,
+                  typeClass: "primitive",
+                  multiple: false,
+                  typeName: "title"
+                },
+                {
+                  value: [
+                    {
+                      authorName: {
+                        value: author,
+                        typeClass: "primitive",
+                        multiple: false,
+                        typeName: "authorName"
+                      }
+                    }
+                  ],
+                  typeClass: "compound",
+                  multiple: true,
+                  typeName: "author"
+                },
+                {
+                  value: [
+                    {
+                      datasetContactEmail: {
+                        value: contact_email,
+                        typeClass: "primitive",
+                        multiple: false,
+                        typeName: "datasetContactEmail"
+                      },
+                      datasetContactName: {
+                        value: author,
+                        typeClass: "primitive",
+                        multiple: false,
+                        typeName: "datasetContactName"
+                      }
+                    }
+                  ],
+                  typeClass: "compound",
+                  multiple: true,
+                  typeName: "datasetContact"
+                },
+                {
+                  value: [
+                    {
+                      dsDescriptionValue: {
+                        value: description,
+                        multiple: false,
+                        typeClass: "primitive",
+                        typeName: "dsDescriptionValue"
+                      }
+                    }
+                  ],
+                  typeClass: "compound",
+                  multiple: true,
+                  typeName: "dsDescription"
+                },
+                {
+                  value: subjects,
+                  typeClass: "controlledVocabulary",
+                  multiple: true,
+                  typeName: "subject"
+                }
+              ],
+              displayName: "Citation Metadata"
+            }
+          }
+        }
+      }.to_json
+    end
+  end
+end

--- a/application/app/models/dataverse/create_dataset_request.rb
+++ b/application/app/models/dataverse/create_dataset_request.rb
@@ -10,7 +10,7 @@ module Dataverse
       @subjects = subjects
     end
 
-    def to_json
+    def to_body
       {
         datasetVersion: {
           metadataBlocks: {

--- a/application/app/models/dataverse/create_dataset_response.rb
+++ b/application/app/models/dataverse/create_dataset_response.rb
@@ -1,0 +1,13 @@
+module Dataverse
+  class CreateDatasetResponse
+    attr_reader :status, :id, :persistent_id, :message
+
+    def initialize(json)
+      parsed = JSON.parse(json, symbolize_names: true)
+      @status = parsed[:status]
+      @id = parsed.dig(:data, :id)
+      @persistent_id = parsed.dig(:data, :persistentId)
+      @message = parsed[:message]
+    end
+  end
+end

--- a/application/app/services/dataverse/dataset_service.rb
+++ b/application/app/services/dataverse/dataset_service.rb
@@ -16,8 +16,10 @@ module Dataverse
 
     def create_dataset(dataverse_id, dataset_data)
       raise ApiKeyRequiredException unless @api_key
+
+      headers = { 'Content-Type' => 'application/json', AUTH_HEADER => @api_key }
       url = "/api/dataverses/#{dataverse_id}/datasets"
-      response = @http_client.post(url, body: dataset_data.to_body, headers: { AUTH_HEADER => @api_key })
+      response = @http_client.post(url, body: dataset_data.to_body, headers: headers)
       return nil if response.not_found?
       raise UnauthorizedException if response.unauthorized?
       raise "Error creating dataset: #{response.status} - #{response.body}" unless response.success?

--- a/application/app/services/dataverse/dataset_service.rb
+++ b/application/app/services/dataverse/dataset_service.rb
@@ -5,17 +5,19 @@ module Dataverse
 
     AUTH_HEADER = 'X-Dataverse-key'
     class UnauthorizedException < Exception; end
+    class ApiKeyRequiredException < Exception; end
 
-    def initialize(dataverse_url, http_client: Common::HttpClient.new(base_url: dataverse_url), api_key:, file_utils: Common::FileUtils.new)
+    def initialize(dataverse_url, http_client: Common::HttpClient.new(base_url: dataverse_url), api_key: nil, file_utils: Common::FileUtils.new)
       @dataverse_url = dataverse_url
       @http_client = http_client
       @file_utils = file_utils
       @api_key = api_key
     end
 
-    def create_dataset(dataverse_id, body, api_key: @api_key)
+    def create_dataset(dataverse_id, dataset_data)
+      raise ApiKeyRequiredException unless @api_key
       url = "/api/dataverses/#{dataverse_id}/datasets"
-      response = @http_client.post(url, body: body.to_json, headers: { AUTH_HEADER => api_key })
+      response = @http_client.post(url, body: dataset_data.to_body, headers: { AUTH_HEADER => @api_key })
       return nil if response.not_found?
       raise UnauthorizedException if response.unauthorized?
       raise "Error creating dataset: #{response.status} - #{response.body}" unless response.success?

--- a/application/app/services/dataverse/dataset_service.rb
+++ b/application/app/services/dataverse/dataset_service.rb
@@ -3,12 +3,23 @@ module Dataverse
     include LoggingCommon
     include DateTimeCommon
 
+    AUTH_HEADER = 'X-Dataverse-key'
     class UnauthorizedException < Exception; end
 
-    def initialize(dataverse_url, http_client: Common::HttpClient.new(base_url: dataverse_url), file_utils: Common::FileUtils.new)
+    def initialize(dataverse_url, http_client: Common::HttpClient.new(base_url: dataverse_url), api_key:, file_utils: Common::FileUtils.new)
       @dataverse_url = dataverse_url
       @http_client = http_client
       @file_utils = file_utils
+      @api_key = api_key
+    end
+
+    def create_dataset(dataverse_id, body, api_key: @api_key)
+      url = "/api/dataverses/#{dataverse_id}/datasets"
+      response = @http_client.post(url, body: body.to_json, headers: { AUTH_HEADER => api_key })
+      return nil if response.not_found?
+      raise UnauthorizedException if response.unauthorized?
+      raise "Error creating dataset: #{response.status} - #{response.body}" unless response.success?
+      CreateDatasetResponse.new(response.body)
     end
   end
 end

--- a/application/test/fixtures/dataverse/create_dataset_response/valid_response.json
+++ b/application/test/fixtures/dataverse/create_dataset_response/valid_response.json
@@ -1,0 +1,7 @@
+{
+  "status": "OK",
+  "data": {
+    "id": 1,
+    "persistentId": "doi:10.70122/FK2/GV5L9W"
+  }
+}

--- a/application/test/models/dataverse/create_dataset_response.rb
+++ b/application/test/models/dataverse/create_dataset_response.rb
@@ -1,0 +1,38 @@
+require "test_helper"
+
+class Dataverse::CreateDatasetResponseTest < ActiveSupport::TestCase
+
+  def setup
+    valid_json = load_file_fixture(File.join('dataverse', 'create_dataset_response', 'valid_response.json'))
+    @response = Dataverse::CreateDatasetResponse.new(valid_json)
+  end
+
+  def empty_json
+    "{}"
+  end
+
+  def empty_string
+    ""
+  end
+
+  test "valid json parses create dataset response" do
+    assert_instance_of Dataverse::CreateDatasetResponse, @response
+    assert_equal "OK", @response.status
+  end
+
+  test "valid json parses valid persistent id and id" do
+    assert_equal 1, @response.id
+    assert_equal "doi:10.70122/FK2/GV5L9W", @response.persistent_id
+  end
+
+  test "create dataset response on empty json does not throw exception" do
+    @invalid_response = Dataverse::CreateDatasetResponse.new(empty_json)
+    assert_instance_of Dataverse::CreateDatasetResponse, @invalid_response
+    assert_nil @invalid_response.persistent_id
+  end
+
+  test "create dataset response with empty string raises JSON::ParserError" do
+    assert_raises(JSON::ParserError) { Dataverse::CreateDatasetResponse.new(empty_string) }
+  end
+
+end


### PR DESCRIPTION
Sample usage code:

```ruby
def test_create
    @dataverse_url = "https://demo.dataverse.org/"
    @service = Dataverse::DataverseService.new(@dataverse_url)
    @citation_metadata = @service.get_citation_metadata
    @body = Dataverse::CreateDatasetRequest.new title: "test service", author: "David",  description: "Lorem ipsum",
                                                contact_email: "david@example.com", subjects: [@citation_metadata.subjects.first]
    @dataset_service = Dataverse::DatasetService.new(@dataverse_url, api_key: "<api_key>")
    @response = @dataset_service.create_dataset(":root", @body)
    render :inline => @response.persistent_id
  end
```