### PR TITLE
Added support to link directly to tab content

### DIFF
--- a/application/app/connectors/dataverse/actions/collection_select.rb
+++ b/application/app/connectors/dataverse/actions/collection_select.rb
@@ -18,6 +18,7 @@ module Dataverse::Actions
       upload_batch.update({ metadata: metadata })
 
       ConnectorResult.new(
+        redirect_url: Rails.application.routes.url_helpers.project_path(id: upload_batch.project_id, anchor: "tab-#{upload_batch.id}"),
         message: { notice: I18n.t('connectors.dataverse.actions.collection_select.success', title: collection_title) },
         success: true
       )

--- a/application/app/connectors/dataverse/actions/connector_edit.rb
+++ b/application/app/connectors/dataverse/actions/connector_edit.rb
@@ -20,6 +20,7 @@ module Dataverse::Actions
       end
 
       ConnectorResult.new(
+        redirect_url: Rails.application.routes.url_helpers.project_path(id: upload_batch.project_id, anchor: "tab-#{upload_batch.id}"),
         message: { notice: I18n.t('connectors.dataverse.actions.connector_edit.success', name: upload_batch.name) },
         success: true
       )

--- a/application/app/connectors/dataverse/actions/dataset_create.rb
+++ b/application/app/connectors/dataverse/actions/dataset_create.rb
@@ -17,6 +17,7 @@ module Dataverse::Actions
       user_profile = user_service.get_user_profile
 
       ConnectorResult.new(
+        redirect_url: Rails.application.routes.url_helpers.project_path(id: upload_batch.project_id, anchor: "tab-#{upload_batch.id}"),
         partial: '/connectors/dataverse/dataset_create_form',
         locals: { upload_batch: upload_batch, profile: user_profile, subjects: subjects }
       )

--- a/application/app/connectors/dataverse/actions/dataset_select.rb
+++ b/application/app/connectors/dataverse/actions/dataset_select.rb
@@ -18,6 +18,7 @@ module Dataverse::Actions
       upload_batch.update({ metadata: metadata })
 
       ConnectorResult.new(
+        redirect_url: Rails.application.routes.url_helpers.project_path(id: upload_batch.project_id, anchor: "tab-#{upload_batch.id}"),
         message: { notice: I18n.t('connectors.dataverse.actions.dataset_select.success', title: dataset_title) },
         success: true
       )

--- a/application/app/connectors/dataverse/upload_batch_connector_metadata.rb
+++ b/application/app/connectors/dataverse/upload_batch_connector_metadata.rb
@@ -2,6 +2,8 @@
 
 module Dataverse
   class UploadBatchConnectorMetadata
+    include Dataverse::Concerns::DataverseUrlBuilder
+
     def initialize(upload_batch)
       @metadata = upload_batch.metadata.to_h.deep_symbolize_keys
       @metadata.each_key do |key|
@@ -33,10 +35,6 @@ module Dataverse
 
     def repo_name
       dataverse_url
-    end
-
-    def dataset_url
-      "#{dataverse_url}/dataset.xhtml?persistentId=#{dataset_id}&version=DRAFT"
     end
 
     def display_collection?

--- a/application/app/connectors/dataverse/upload_batch_connector_processor.rb
+++ b/application/app/connectors/dataverse/upload_batch_connector_processor.rb
@@ -11,7 +11,7 @@ module Dataverse
     end
 
     def params_schema
-      %i[remote_repo_url form api_key key_scope collection_id dataset_id title description author contact_email subject]
+      %i[remote_repo_url form active_tab api_key key_scope collection_id dataset_id title description author contact_email subject]
     end
 
     def create(project, request_params)
@@ -62,6 +62,7 @@ module Dataverse
       upload_batch.save
 
       ConnectorResult.new(
+        redirect_url: Rails.application.routes.url_helpers.project_path(id: project.id, anchor: "tab-#{upload_batch.id}"),
         message: { notice: I18n.t('connectors.dataverse.upload_batches.created', name: upload_batch.name) },
         success: true
       )

--- a/application/app/controllers/upload_batches_controller.rb
+++ b/application/app/controllers/upload_batches_controller.rb
@@ -22,7 +22,8 @@ class UploadBatchesController < ApplicationController
     processor_params = params.permit(*processor.params_schema).to_h
     processor_params[:object_url] = url_resolution.object_url
     result = processor.create(project, processor_params)
-    redirect_back fallback_location: root_path, **result.message
+
+    redirect_to result.redirect_url, **result.message
   end
 
   def edit
@@ -56,7 +57,7 @@ class UploadBatchesController < ApplicationController
     log_info("params", {params: processor_params})
     result = processor.update(upload_batch, processor_params)
 
-    redirect_back fallback_location: root_path, **result.message
+    redirect_to result.redirect_url, **result.message
   end
 
   def destroy

--- a/application/app/javascript/controllers/utils/tab_links_controller.js
+++ b/application/app/javascript/controllers/utils/tab_links_controller.js
@@ -1,0 +1,23 @@
+import { Controller } from '@hotwired/stimulus'
+
+export default class extends Controller {
+    connect() {
+        const hash = window.location.hash
+        if (hash) {
+            const tabTriggerEl = document.querySelector(`a[href="${hash}"]`)
+            if (tabTriggerEl && window.bootstrap?.Tab) {
+                const tab = new window.bootstrap.Tab(tabTriggerEl)
+                tab.show()
+            }
+        }
+
+        this.element.querySelectorAll('a[data-bs-toggle="tab"]').forEach(el => {
+            el.addEventListener('shown.bs.tab', event => {
+                const href = event.target.getAttribute('href')
+                if (href && history.replaceState) {
+                    history.replaceState(null, '', href)
+                }
+            })
+        })
+    }
+}

--- a/application/app/services/dataverse/concerns/dataverse_url_builder.rb
+++ b/application/app/services/dataverse/concerns/dataverse_url_builder.rb
@@ -1,0 +1,17 @@
+module Dataverse::Concerns::DataverseUrlBuilder
+  extend ActiveSupport::Concern
+
+  def collection_url
+    raise 'collection_id is missing' unless collection_id
+
+    "#{dataverse_url}/dataverse/#{collection_id}"
+  end
+
+  def dataset_url(version: nil)
+    raise 'dataset_id (DOI) is missing' unless dataset_id
+
+    url = "#{dataverse_url}/dataset.xhtml?persistentId=#{dataset_id}"
+    url += "&version=#{version}" if version
+    url
+  end
+end

--- a/application/app/services/dataverse/dataverse_url.rb
+++ b/application/app/services/dataverse/dataverse_url.rb
@@ -2,6 +2,8 @@
 
 module Dataverse
   class DataverseUrl
+    include Dataverse::Concerns::DataverseUrlBuilder
+
     TYPES = %w[dataverse collection dataset file unknown].freeze
 
     attr_reader :type, :collection_id, :dataset_id, :file_id, :version
@@ -38,20 +40,6 @@ module Dataverse
     def dataverse_url
       uri_class = @base.https? ? URI::HTTPS : URI::HTTP
       uri_class.build(host: @base.domain, port: @base.port).to_s
-    end
-
-    def collection_url
-      raise 'collection_id is missing' unless @collection_id
-
-      "#{dataverse_url}/dataverse/#{@collection_id}"
-    end
-
-    def dataset_url(version: nil)
-      raise 'dataset_id (DOI) is missing' unless @dataset_id
-
-      url = "#{dataverse_url}/dataset.xhtml?persistentId=#{@dataset_id}"
-      url += "&version=#{version}" if version
-      url
     end
 
     def initialize(base_parser)

--- a/application/app/views/connectors/dataverse/_upload_batch_actions_bar.html.erb
+++ b/application/app/views/connectors/dataverse/_upload_batch_actions_bar.html.erb
@@ -7,12 +7,16 @@
     <div class="mb-1"><%= connector_icon(upload_batch.type) %></div>
     <!-- UPLOAD DATASET INFO -->
     <div class="d-flex flex-column">
-        <span class="text-truncate d-inline-block" style="max-width: 800px;" title="<%= upload_batch.connector_metadata.dataset_title %>">
-          <%= upload_batch.connector_metadata.dataverse_title %>
-          <span class="text-muted mx-1 position-relative" style="font-size: 1.2rem;">»</span>
+        <span class="text-truncate d-inline-block" style="max-width: 800px;">
+          <a href="<%= upload_batch.connector_metadata.dataverse_url %>" target="_blank" class="text-reset text-decoration-none" title="<%= upload_batch.connector_metadata.dataverse_title %>">
+            <%= upload_batch.connector_metadata.dataverse_title %>
+          </a>
+          <span class="text-muted mx-1 position-relative" style="font-size: 1.2rem;">&raquo;</span>
 
           <% if upload_batch.connector_metadata.display_collection? %>
-            <%= upload_batch.connector_metadata.collection_title %>
+            <a href="<%= upload_batch.connector_metadata.collection_url %>" target="_blank" class="text-reset text-decoration-none" title="<%= upload_batch.connector_metadata.collection_title %>">
+              <%= upload_batch.connector_metadata.collection_title %>
+            </a>
           <% end %>
           <% if upload_batch.connector_metadata.select_collection? %>
             <button type="button"
@@ -29,7 +33,9 @@
           <% end %>
           <% if upload_batch.connector_metadata.display_dataset? %>
             <small class="text-muted mx-1 position-relative" style="top: -0.8px;">&gt;</small>
-            <%= upload_batch.connector_metadata.dataset_title %>
+            <a href="<%= upload_batch.connector_metadata.dataset_url %>" target="_blank" class="text-reset text-decoration-none" title="<%= upload_batch.connector_metadata.dataset_title %>">
+              <%= upload_batch.connector_metadata.dataset_title %>
+            </a>
           <% end %>
           <% if upload_batch.connector_metadata.select_dataset? %>
             <small class="text-muted mx-1 position-relative" style="top: -0.8px;">&gt;</small>

--- a/application/app/views/connectors/dataverse/_upload_batch_info_bar.html.erb
+++ b/application/app/views/connectors/dataverse/_upload_batch_info_bar.html.erb
@@ -8,15 +8,21 @@
     <!-- UPLOAD DATASET INFO -->
     <div class="d-flex flex-column">
         <span class="text-truncate d-inline-block" style="max-width: 800px;" title="<%= upload_batch.connector_metadata.dataset_title %>">
-          <%= upload_batch.connector_metadata.dataverse_title %>
-          <span class="text-muted mx-1 position-relative" style="font-size: 1.2rem;">»</span>
+          <a href="<%= upload_batch.connector_metadata.dataverse_url %>" target="_blank" class="text-reset text-decoration-none" title="<%= upload_batch.connector_metadata.dataverse_title %>">
+            <%= upload_batch.connector_metadata.dataverse_title %>
+          </a>
+          <span class="text-muted mx-1 position-relative" style="font-size: 1.2rem;">&raquo;</span>
 
           <% if upload_batch.connector_metadata.display_collection? %>
-            <%= upload_batch.connector_metadata.collection_title %>
+            <a href="<%= upload_batch.connector_metadata.collection_url %>" target="_blank" class="text-reset text-decoration-none" title="<%= upload_batch.connector_metadata.collection_title %>">
+              <%= upload_batch.connector_metadata.collection_title %>
+            </a>
           <% end %>
           <% if upload_batch.connector_metadata.display_dataset? %>
             <small class="text-muted mx-1 position-relative" style="top: -0.8px;">&gt;</small>
-            <%= upload_batch.connector_metadata.dataset_title %>
+            <a href="<%= upload_batch.connector_metadata.dataset_url %>" target="_blank" class="text-reset text-decoration-none" title="<%= upload_batch.connector_metadata.dataset_title %>">
+               <%= upload_batch.connector_metadata.dataset_title %>
+             </a>
           <% end %>
         </span>
 

--- a/application/app/views/projects/_project_summary.html.erb
+++ b/application/app/views/projects/_project_summary.html.erb
@@ -23,24 +23,24 @@
 </div>
 
 <!-- Collapsible Tabs -->
-<div class="collapse" id="project-files-<%= project.id %>">
+<div class="collapse" id="project-files-<%= project.id %>" data-controller="utils--tab-links">
   <div class="bg-light pt-2">
     <!-- Tabs -->
     <ul class="nav nav-tabs" id="tabs-<%= project.id %>" role="tablist">
       <li class="nav-item" role="presentation">
-        <button class="nav-link text-secondary active" id="download-tab-<%= project.id %>" data-bs-toggle="tab"
-                data-bs-target="#download-files-<%= project.id %>" type="button" role="tab"
-                aria-controls="download-files-<%= project.id %>" aria-selected="true">
+        <a class="nav-link text-secondary active" id="download-tab" data-bs-toggle="tab"
+           href="#download-files-<%= project.id %>" role="tab"
+           aria-controls="download-files-<%= project.id %>" aria-selected="true">
           <i class="bi bi-download me-1"></i><%= t('.tab_download_label') %>
-        </button>
+        </a>
       </li>
       <% project.upload_batches.each do |batch| %>
         <li class="nav-item" role="presentation">
-          <button class="nav-link text-secondary" id="upload-tab-<%= batch.id %>" data-bs-toggle="tab"
-                  data-bs-target="#upload-files-<%= batch.id %>" type="button" role="tab"
-                  aria-controls="upload-files-<%= batch.id %>" aria-selected="false">
+          <a class="nav-link text-secondary" id="upload-tab-<%= batch.id %>" data-bs-toggle="tab"
+             href="#upload-files-<%= batch.id %>" role="tab"
+             aria-controls="upload-files-<%= batch.id %>" aria-selected="false">
             <i class="bi bi-upload me-1"></i><%= batch.name %>
-          </button>
+          </a>
         </li>
       <% end %>
     </ul>

--- a/application/app/views/projects/_upload_batch.html.erb
+++ b/application/app/views/projects/_upload_batch.html.erb
@@ -7,7 +7,7 @@
           <%= render partial: '/shared/file_row_date', locals: { date: file.creation_date, title: t('.schedule_date'), classes: 'mx-2'} %>
 
           <%= render partial: 'shared/repo_badge', locals: {
-            repo_url: upload_batch.connector_metadata.dataset_url,
+            repo_url: upload_batch.connector_metadata.dataverse_url,
             target: '_blank',
             icon_html: connector_icon(file.type),
             name: upload_batch.connector_metadata.dataverse_title,

--- a/application/app/views/projects/show.html.erb
+++ b/application/app/views/projects/show.html.erb
@@ -7,7 +7,6 @@
 
       <%= render partial: '/projects/show/project_tabs', locals: { project: @project } %>
       <div class="tab-content">
-        <%= render partial: '/projects/show/project_metadata', locals: { project: @project, active: true } %>
         <%= render partial: '/projects/show/download_files', locals: { project: @project } %>
         <% @project.upload_batches.each do |batch| %>
           <%= render partial: '/projects/show/upload_batch', locals: { project: @project, batch: batch } %>

--- a/application/app/views/projects/show/_download_files.html.erb
+++ b/application/app/views/projects/show/_download_files.html.erb
@@ -1,5 +1,5 @@
 <% files = project.download_files %>
-<div id="tab-download-files" class="tab-pane fade show" role="tabpanel" aria-labelledby="tab-download-files">
+<div id="tab-download-files" class="tab-pane fade show active" role="tabpanel" aria-labelledby="tab-download-files">
   <%= render partial: '/projects/show/download_actions', locals: { project: project } %>
 
   <div class="container files rounded border">

--- a/application/app/views/projects/show/_project_actions.html.erb
+++ b/application/app/views/projects/show/_project_actions.html.erb
@@ -1,4 +1,4 @@
-<div class="d-flex justify-content-between align-items-center">
+<div class="d-flex justify-content-between align-items-center mt-3">
   <div class="d-flex align-items-center gap-2">
     <a href="<%= files_app_url(project.download_dir) %>"
        target="_blank"
@@ -6,7 +6,8 @@
        title="<%= t('.open_project_folder') %>">
       <i class="bi bi-folder-fill"></i>
     </a>
-    <h5 class="mb-0 me-2"><%= project.name %></h5>
+    <%= render partial: '/shared/file_row_date', locals: { date: project.creation_date, title: t('.creation_date'), classes: ''} %>
+    <h5 class="mb-0 me-2 fs-4"><%= project.name %></h5>
   </div>
 
   <div class="d-flex align-items-center gap-2 flex-grow-1">

--- a/application/app/views/projects/show/_project_tabs.html.erb
+++ b/application/app/views/projects/show/_project_tabs.html.erb
@@ -1,28 +1,21 @@
 <!-- Project Tabs -->
-<div id="project-tabs" class="mb-3">
+<div id="project-tabs" class="mb-3" data-controller="utils--tab-links">
   <ul class="nav nav-tabs" id="project-tabs-<%= project.id %>" role="tablist">
     <li class="nav-item" role="presentation">
-      <button class="nav-link text-secondary active" id="metadata-tab" data-bs-toggle="tab"
-              data-bs-target="#tab-project-metadata" type="button" role="tab"
-              aria-controls="project-metadata" aria-selected="true">
-        <i class="bi bi-collection me-1"></i><%= t('.project') %>
-      </button>
-    </li>
-    <li class="nav-item" role="presentation">
-      <button class="nav-link text-secondary" id="download-tab" data-bs-toggle="tab"
-              data-bs-target="#tab-download-files" type="button" role="tab"
-              aria-controls="download-files" aria-selected="false">
+      <a class="nav-link text-secondary active" id="download-tab" data-bs-toggle="tab"
+         href="#tab-download-files" role="tab"
+         aria-controls="download-files" aria-selected="true">
         <i class="bi bi-download me-1"></i><%= t('.download_files') %>
-      </button>
+      </a>
     </li>
 
     <% project.upload_batches.each do |upload_batch| %>
       <li class="nav-item" role="presentation">
-        <button class="nav-link text-secondary" id="upload-tab-<%= upload_batch.id %>" data-bs-toggle="tab"
-                data-bs-target="#tab-upload-batch-<%= upload_batch.id %>" type="button" role="tab"
-                aria-controls="upload-files-<%= upload_batch.id %>" aria-selected="false">
+        <a class="nav-link text-secondary" id="upload-tab-<%= upload_batch.id %>" data-bs-toggle="tab"
+           href="#tab-<%= upload_batch.id %>" role="tab"
+           aria-controls="upload-files-<%= upload_batch.id %>" aria-selected="false">
           <i class="bi bi-upload me-1"></i><%= upload_batch.name %>
-        </button>
+        </a>
       </li>
     <% end %>
   </ul>

--- a/application/app/views/projects/show/_upload_actions.html.erb
+++ b/application/app/views/projects/show/_upload_actions.html.erb
@@ -28,11 +28,6 @@
         <span class="ps-1"><%= t('.add_files') %></span>
       </button>
 
-      <button class="btn btn-sm btn-outline-secondary"
-              title="<%= t('.edit_upload_batch_settings') %>">
-        <i class="bi bi-gear-fill"></i>
-      </button>
-
       <%= render partial: "shared/button_to", locals: {
         url: project_upload_batch_path(project_id: batch.project_id, id: batch.id),
         method: 'DELETE',

--- a/application/app/views/projects/show/_upload_batch.html.erb
+++ b/application/app/views/projects/show/_upload_batch.html.erb
@@ -3,7 +3,7 @@
   file_target_id = "fbt-#{batch.id}"
   upload_files_id = "upload-files-#{batch.id}"
 %>
-<div id="tab-upload-batch-<%= batch.id %>" class="tab-pane fade" role="tabpanel" aria-labelledby="upload-tab-<%= batch.id %>">
+<div id="tab-<%= batch.id %>" class="tab-pane fade" role="tabpanel" aria-labelledby="upload-tab-<%= batch.id %>">
   <%= render partial: '/projects/show/upload_actions', locals: { batch: batch, file_browser_id: file_browser_id, upload_files_id: upload_files_id } %>
 
   <%= render layout: '/file_browser/file_drop', locals: { id: file_target_id, file_browser_id: file_browser_id, url: project_upload_batch_upload_files_path(project_id: project.id, upload_batch_id: batch.id) } do %>

--- a/application/app/views/upload_status/_files.html.erb
+++ b/application/app/views/upload_status/_files.html.erb
@@ -19,7 +19,7 @@
               </div>
 
               <%= render partial: 'shared/repo_badge', locals: {
-                repo_url: data.upload_batch.connector_metadata.dataset_url,
+                repo_url: data.upload_batch.connector_metadata.dataverse_url,
                 target: '_blank',
                 icon_html: connector_icon(data.file.type),
                 name: data.upload_batch.connector_metadata.dataverse_title,

--- a/application/config/locales/views/en.yml
+++ b/application/config/locales/views/en.yml
@@ -168,6 +168,7 @@ en:
         delete_file: "Delete File"
       project_actions:
         open_project_folder: "Open project folder"
+        creation_date: "Creation date"
         create_upload_batch: "Create Upload Batch"
         create_upload_batch_placeholder: "Dataset URL"
         delete_project: "Delete Project"

--- a/application/test/services/dataverse/concerns/dataverse_url_builder.rb
+++ b/application/test/services/dataverse/concerns/dataverse_url_builder.rb
@@ -1,0 +1,47 @@
+# frozen_string_literal: true
+
+require 'test_helper'
+
+class DummyDataverseUrlBuilder
+  include Dataverse::Concerns::DataverseUrlBuilder
+
+  attr_accessor :dataverse_url, :collection_id, :dataset_id
+end
+
+class Dataverse::Concerns::DataverseUrlBuilderTest < ActiveSupport::TestCase
+  def setup
+    @builder = DummyDataverseUrlBuilder.new
+    @builder.dataverse_url = 'https://demo.dataverse.org'
+    @builder.collection_id = 'test-collection'
+    @builder.dataset_id = 'doi:10.5072/FK2/ABC123'
+  end
+
+  test 'collection_url builds correct URL' do
+    expected = 'https://demo.dataverse.org/dataverse/test-collection'
+    assert_equal expected, @builder.collection_url
+  end
+
+  test 'collection_url raises when collection_id is missing' do
+    @builder.collection_id = nil
+    assert_raises(RuntimeError, 'collection_id is missing') do
+      @builder.collection_url
+    end
+  end
+
+  test 'dataset_url builds URL without version' do
+    expected = 'https://demo.dataverse.org/dataset.xhtml?persistentId=doi:10.5072/FK2/ABC123'
+    assert_equal expected, @builder.dataset_url
+  end
+
+  test 'dataset_url builds URL with version' do
+    expected = 'https://demo.dataverse.org/dataset.xhtml?persistentId=doi:10.5072/FK2/ABC123&version=2.0'
+    assert_equal expected, @builder.dataset_url(version: '2.0')
+  end
+
+  test 'dataset_url raises when dataset_id is missing' do
+    @builder.dataset_id = nil
+    assert_raises(RuntimeError, 'dataset_id (DOI) is missing') do
+      @builder.dataset_url
+    end
+  end
+end


### PR DESCRIPTION
Minor UI improvements.

Added links to the Dataverse, Collection and Dataset on UploadCollections.

Added support to link directly to the content of a tab.
To check the new behaviour:
- Select a collection
- Select a dataset
- Create a dataset
- Add/update API key

In all these cases, the active tab should be open again.
