### PR TITLE
fix: Fixed repo resolver Stimulus controller

### DIFF
--- a/application/app/views/layouts/_repo_resolver_bar.html.erb
+++ b/application/app/views/layouts/_repo_resolver_bar.html.erb
@@ -9,7 +9,7 @@
     </div>
 
     <!-- Resolver Form (right aligned) -->
-    <form action="<%= repo_resolver_path %>" method="post" class="d-flex align-items-center gap-3" style="flex: 1 1 auto; max-width: 60%;">
+    <form data-controller="submit-button" action="<%= repo_resolver_path %>" method="post" class="d-flex align-items-center gap-3" style="flex: 1 1 auto; max-width: 60%;">
       <%= hidden_field_tag :authenticity_token, form_authenticity_token %>
 
       <input type="text"
@@ -20,7 +20,7 @@
              style="flex: 1 1 auto;">
 
       <button class="btn btn-sm btn-primary px-3" type="submit"
-              data-controller="submit-button"
+              data-submit-button-target="button"
               data-action="click->submit-button#click">
         <span data-submit-button-target="spinner"
               class="spinner-border spinner-border-sm me-1 d-none"


### PR DESCRIPTION
Title:
Fix Stimulus controller configuration for repo resolver form

Description:
This PR updates the repository resolver form to correctly configure the Stimulus controller and its targets. It ensures that the form and submit button interact properly for the intended dynamic behavior.

Moves data-controller="submit-button" to the form element.
Corrects data-submit-button-target usage on the submit button.

Closes #188.

