### PR TITLE
Added Dataverse URL validation to DatasetController

### DIFF
--- a/application/app/controllers/dataverse/datasets_controller.rb
+++ b/application/app/controllers/dataverse/datasets_controller.rb
@@ -3,6 +3,7 @@ class Dataverse::DatasetsController < ApplicationController
   include Dataverse::CommonHelper
 
   before_action :get_dv_full_hostname
+  before_action :validate_dataverse_url
   before_action :init_service
   before_action :init_project_service, only: [ :download ]
   before_action :find_dataset_by_persistent_id
@@ -46,6 +47,15 @@ class Dataverse::DatasetsController < ApplicationController
 
   def get_dv_full_hostname
     @dataverse_url = current_dataverse_url
+  end
+
+  def validate_dataverse_url
+    resolver = Repo::RepoResolverService.new(RepoRegistry.resolvers)
+    result = resolver.resolve(@dataverse_url)
+    unless result.type == ConnectorType::DATAVERSE
+      redirect_back fallback_location: root_path, alert: t('dataverse.datasets.url_not_supported', dataverse_url: @dataverse_url)
+      return
+    end
   end
 
   def init_service

--- a/application/config/locales/controllers/dataverse/en.yml
+++ b/application/config/locales/controllers/dataverse/en.yml
@@ -17,6 +17,7 @@ en:
       dataverse_service_error: "Dataverse service error. Dataverse: %{dataverse_url} persistentId: %{persistent_id}"
       dataset_files_not_found: "Dataset files not found. Dataverse: %{dataverse_url} persistentId: %{persistent_id} page: %{page}"
       dataset_files_endpoint_requires_authorization: "Dataset files endpoint requires authorization. Dataverse: %{dataverse_url} persistentId: %{persistent_id} page: %{page}"
+      url_not_supported: "Dataverse URL not supported: %{dataverse_url}"
       dataverse_service_error_searching_files: "Dataverse service error while searching files. Dataverse: %{dataverse_url} persistentId: %{persistent_id} page: %{page}"
     landing_page:
       index:


### PR DESCRIPTION
Improve DatasetControler security by verifying that the domain htat comes in the request is a valid Dataverse domain.

Fixes #79