### PR TITLE
fix: Fixed upload badge repo size

### DIFF
--- a/application/app/views/upload_status/_files.html.erb
+++ b/application/app/views/upload_status/_files.html.erb
@@ -48,7 +48,7 @@
                 type: data.upload_bundle.type,
                 text: data.upload_bundle.connector_metadata.dataverse_title,
                 tooltip: t(".badge_repo_tooltip"),
-                small: true
+                small: false
               } %>
 
               <span class="me-2"><%= data.project.name %> ></span>


### PR DESCRIPTION
Fix to the badge size after the refactoring to use the new DV logo