### PR TITLE
fix: Fixed dataset file restrictions UI

### DIFF
--- a/application/app/lib/logging_common.rb
+++ b/application/app/lib/logging_common.rb
@@ -9,7 +9,7 @@ module LoggingCommon
 
     if exception
       # First 5 lines as a stack trace
-      log_message += "\n[STACK] " + exception.message
+      log_message += "\n[STACK] #{exception.class}: #{exception.message}"
       log_message += "\n[STACK] " + exception.backtrace&.first(5)&.join("\n[STACK] ")
     end
 

--- a/application/app/services/dataverse/dataverse_restrictions_service.rb
+++ b/application/app/services/dataverse/dataverse_restrictions_service.rb
@@ -21,10 +21,18 @@ module Dataverse
 
     def validate_dataset_file(file)
       response = { valid?: true, message: nil }
+
+      if file.restricted
+        response = {
+          valid?: false,
+          message: I18n.t('dataverse.restrictions.dataset_file.restricted_message')
+        }
+      end
+
       if file.data_file.nil?
         response = {
           valid?: false,
-          message: "File data is not present"
+          message: I18n.t('dataverse.restrictions.dataset_file.missing_file_message')
         }
       end
 
@@ -32,7 +40,7 @@ module Dataverse
         helpers = ActionController::Base.helpers
         response = {
           valid?: false,
-          message: "Files bigger than #{helpers.number_to_human_size(dataverse_restrictions.max_file_size)} are not supported"
+          message: I18n.t('dataverse.restrictions.dataset_file.file_size_message', max_size: helpers.number_to_human_size(dataverse_restrictions.max_file_size))
         }
       end
 

--- a/application/app/services/dataverse/dataverse_restrictions_service.rb
+++ b/application/app/services/dataverse/dataverse_restrictions_service.rb
@@ -27,16 +27,12 @@ module Dataverse
           valid?: false,
           message: I18n.t('dataverse.restrictions.dataset_file.restricted_message')
         }
-      end
-
-      if file.data_file.nil?
+      elsif file.data_file.nil?
         response = {
           valid?: false,
           message: I18n.t('dataverse.restrictions.dataset_file.missing_file_message')
         }
-      end
-
-      if file&.data_file&.filesize and file.data_file.filesize > dataverse_restrictions.max_file_size
+      elsif file&.data_file&.filesize and file.data_file.filesize > dataverse_restrictions.max_file_size
         helpers = ActionController::Base.helpers
         response = {
           valid?: false,

--- a/application/app/services/download/basic_http_ruby_downloader.rb
+++ b/application/app/services/download/basic_http_ruby_downloader.rb
@@ -38,7 +38,7 @@ module Download
             return download_follow_redirects(new_url, file_path, headers, limit - 1, &)
           end
 
-          raise "Failed to download: #{response.code}" unless response.is_a?(Net::HTTPSuccess)
+          raise "Failed to download: (HTTP: #{response.code}) #{response.body}" unless response.is_a?(Net::HTTPSuccess)
 
           total_downloaded = 0  # Initialize the total downloaded size
           File.open(file_path, "wb") do |file|

--- a/application/app/views/dataverse/datasets/_dataset_file_row.html.erb
+++ b/application/app/views/dataverse/datasets/_dataset_file_row.html.erb
@@ -3,12 +3,12 @@
   row_classes = restrictions_response.valid? ? '' : 'table-row-disabled'
 %>
 <tr class="<%= row_classes %>" title="<%= restrictions_response.message %>">
-  <td>
-    <div class="form-check">
-      <% if restrictions_response.valid? %>
+  <td class="text-nowrap p-0 align-middle" style="width: 1%;">
+    <div class="d-flex justify-content-center align-items-center" style="min-width: 3rem;">
+    <% if restrictions_response.valid? %>
         <%= check_box_tag("file_ids[]", file&.data_file&.id, false, class: "form-check-input", id: "file_checkbox_#{file&.data_file&.id}", data: {"utils--checkbox-target" => "item", action: "utils--checkbox#updateState"}) %>
     <% else %>
-        <i class="fas fa-circle-info" aria-hidden="true"></i>
+        <i class="bi bi-info-circle-fill" aria-hidden="true"></i>
         <span class="visually-hidden"><%= restrictions_response.message %></span>
       <% end %>
     </div>

--- a/application/app/views/dataverse/datasets/_dataset_files.html.erb
+++ b/application/app/views/dataverse/datasets/_dataset_files.html.erb
@@ -22,12 +22,12 @@
           <caption class="visually-hidden"><%= t('dataverse.datasets.dataset_files.table_dataset_files_caption') %></caption>
           <thead class="table-light">
           <tr>
-            <th scope="col">
-              <div class="form-check">
-                <label class="form-check-label visually-hidden" for="select_all_files">
+            <th scope="col" class="text-nowrap p-0 align-middle" style="width: 1%;">
+              <div class="d-flex justify-content-center align-items-center" style="min-width: 3rem;">
+                <label class="visually-hidden" for="select_all_files">
                   <%= t('dataverse.datasets.dataset_files.checkbox_select_all_label') %>
                 </label>
-                <input class="form-check-input" type="checkbox" id="select_all_files" data-utils--checkbox-target="selectAll" data-action="utils--checkbox#toggleSelectAll">
+                <input type="checkbox" id="select_all_files" class="form-check-input m-0" data-utils--checkbox-target="selectAll" data-action="utils--checkbox#toggleSelectAll">
               </div>
             </th>
             <th scope="col"><%= t('dataverse.datasets.dataset_files.col_file_name_text') %></th>

--- a/application/app/views/dataverse/datasets/show.html.erb
+++ b/application/app/views/dataverse/datasets/show.html.erb
@@ -4,7 +4,7 @@
 %>
 
 <% content_for :title, t('dataverse.datasets.show.page_title') %>
-<div class="container-md content" role="main">
+<div class="dataverse container-md content" role="main">
   <%= render partial: 'dataverse/datasets/breadcrumbs', locals: { dataverse_url: @dataverse_url, dataset: @dataset} %>
     <div class="row">
     <div class="col-md-12">

--- a/application/config/locales/connectors/dataverse/en.yml
+++ b/application/config/locales/connectors/dataverse/en.yml
@@ -155,6 +155,12 @@ en:
         breadcrumb_home_title: "Home"
         image_dataverse_icon_alt: "Dataverse icon"
         page_title: "OnDemand Loop - Dataverse Landing page"
+
+    restrictions:
+      dataset_file:
+        restricted_message: "File is restricted. Restricted files not supported"
+        missing_file_message: "File data is not present"
+        file_size_message: "Files bigger than %{max_size} are not supported"
   helpers:
     dataverse:
       invalid_hostname: "Invalid Dataverse hostname"


### PR DESCRIPTION
Fixed UI for restricted files. This was broken as it was using FA icons

<img width="671" height="654" alt="Screenshot 2025-07-10 at 16 12 19" src="https://github.com/user-attachments/assets/0f0b86ec-bf72-42e5-8543-37641e65182e" />
