### PR TITLE
Doc user guide review

### DIFF
--- a/docs/guide/content/user_guide/downloading_files.md
+++ b/docs/guide/content/user_guide/downloading_files.md
@@ -50,7 +50,7 @@ At the top of the Downloads tab, a summary panel displays key information about 
     - **Pending** – Files waiting to be processed.
     - **Completed** – Successfully downloaded files.
     - **Cancelled** – Downloads that were manually cancelled before completion.
-    - **Error** – Downloads that failed due to networkm, a repository issue or a failed checksum verification.
+    - **Error** – Downloads that failed due to network, a repository issue or a failed checksum verification.
     - **Total** – The total number of download requests.
 
 The large circular indicator highlights the **percentage of completed downloads**, helping you quickly assess progress at a glance.

--- a/docs/guide/content/user_guide/downloading_files.md
+++ b/docs/guide/content/user_guide/downloading_files.md
@@ -10,8 +10,10 @@ After locating a dataset (via DOI, URL, or browsing), you can download specific 
 1. **Select files**  
    On the dataset page, use the checkboxes to select the files you want to download.
 2. **Add to project**  
-   When at least one file is selected, the **Add Files to Active Project** button becomes enabled. Clicking it schedules the selected files for download to the active project.
-    - If no project is active, OnDemand Loop automatically creates a new one.
+   When at least one file is selected, the **Add Files to New Project** or **Add Files to Active Project** button becomes enabled. Clicking it schedules the selected files for download to a Project.
+    - The text of the button depends on the presence of an Active Project in the application.
+    - If no Project is active, OnDemand Loop automatically creates a new one.
+    - To make all downloads go to the same specific Project, set that Project as Active.
 3. **Track progress**  
    Monitor download activity in two places:
     - The **Downloads** tab of the selected project (shows only that project's files)
@@ -27,8 +29,13 @@ After locating a dataset (via DOI, URL, or browsing), you can download specific 
 
 ### Project Detail Page – Downloads Tab
 
-Each project includes a **Downloads** tab showing its associated download requests.
+Each project detail page includes a **Downloads** tab showing its associated download requests.
 The data is displayed in a table format, where each row represents a file and shows key metadata.
+
+!!! warning
+
+    Project list view displays a summary of the downloads. The full information of the dowloaded files is displayed
+    on the Project detail page.
 
 #### Downloads Tab Header
 
@@ -43,7 +50,7 @@ At the top of the Downloads tab, a summary panel displays key information about 
     - **Pending** – Files waiting to be processed.
     - **Completed** – Successfully downloaded files.
     - **Cancelled** – Downloads that were manually cancelled before completion.
-    - **Error** – Downloads that failed due to network or repository issues.
+    - **Error** – Downloads that failed due to networkm, a repository issue or a failed checksum verification.
     - **Total** – The total number of download requests.
 
 The large circular indicator highlights the **percentage of completed downloads**, helping you quickly assess progress at a glance.
@@ -106,7 +113,7 @@ At the top of the global **Downloads** page, a summary panel displays the curren
 
 #### Behavior
 
-- Files are **queued** when system resources are busy (`pending` state).
+- Files are **queued** when another download is already in progress (`pending` state).
 - Downloads in progress show a **progress bar**, updated every 5 seconds.
 - Completed downloads remain visible for **24 hours** in the global view.
 - After that, they are only listed in the project's Downloads tab.
@@ -133,6 +140,13 @@ original_file_02.csv
 
 
 Each version is treated as a separate task and stored independently.
+
+---
+
+### Checksum verification
+
+A checksum verification is done after each file is downloaded. In case of invalid verification, `error` state
+will be displayed for that file despite being transferred entirely.
 
 ---
 

--- a/docs/guide/content/user_guide/downloading_files.md
+++ b/docs/guide/content/user_guide/downloading_files.md
@@ -10,10 +10,10 @@ After locating a dataset (via DOI, URL, or browsing), you can download specific 
 1. **Select files**  
    On the dataset page, use the checkboxes to select the files you want to download.
 2. **Add to project**  
-   When at least one file is selected, the **Add Files to New Project** or **Add Files to Active Project** button becomes enabled. Clicking it schedules the selected files for download to a Project.
-    - The text of the button depends on the presence of an Active Project in the application.
-    - If no Project is active, OnDemand Loop automatically creates a new one.
-    - To make all downloads go to the same specific Project, set that Project as Active.
+   When at least one file is selected, the **Add Files to New Project** or **Add Files to Active Project** button becomes enabled. Clicking it schedules the selected files for download to a project.
+    - The text of the button depends on the presence of an active project in the application.
+    - If no Project is active, OnDemand Loop automatically creates a new one everytime files are added.
+    - To make all downloads go to the same specific project, set that Project as Active.
 3. **Track progress**  
    Monitor download activity in two places:
     - The **Downloads** tab of the selected project (shows only that project's files)
@@ -113,7 +113,7 @@ At the top of the global **Downloads** page, a summary panel displays the curren
 
 #### Behavior
 
-- Files are **queued** when another download is already in progress (`pending` state).
+- Files are automatically **queued** when system limits for concurrent downloads are reached (`pending` state).
 - Downloads in progress show a **progress bar**, updated every 5 seconds.
 - Completed downloads remain visible for **24 hours** in the global view.
 - After that, they are only listed in the project's Downloads tab.
@@ -143,10 +143,12 @@ Each version is treated as a separate task and stored independently.
 
 ---
 
-### Checksum verification
+### Checksum Verification
 
-A checksum verification is done after each file is downloaded. In case of invalid verification, `error` state
-will be displayed for that file despite being transferred entirely.
+After each file is downloaded, OnDemand Loop automatically verifies its integrity using a checksum provided by the remote repository.  
+If the verification fails, the file is marked with an **`error`** status, even if the download appears to have completed successfully.
+
+This ensures that only fully intact and verified files are considered valid and usable.
 
 ---
 

--- a/docs/guide/content/user_guide/finding_data.md
+++ b/docs/guide/content/user_guide/finding_data.md
@@ -60,9 +60,10 @@ OnDemand Loop will:
 If you prefer an integrated experience or are still exploring:
 
 1. Click on the **Repositories** menu in the app.
-2. Choose a supported remote repository.
-3. Use the built-in search to look for datasets.
-4. Navigate the results and select a dataset to preview or download.
+2. Choose a supported remote repository, like **Dataverse** or **Zenodo**.
+3. In case of the existence of multiple repository installations, select the desired one.
+4. Use the built-in search to look for datasets.
+5. Navigate the results and select a dataset to explore.
 
 Once a dataset is selected, OnDemand Loop presents its metadata and file listing so you can choose what to download into your project.
 

--- a/docs/guide/content/user_guide/index.md
+++ b/docs/guide/content/user_guide/index.md
@@ -37,5 +37,5 @@ Built‑in repository connectors handle the details of each repository’s API, 
     - The **Explore** link toggles a bar where you can paste a DOI or repository URL.
     - On the far right you’ll see links to **Open OnDemand** (which returns you to the main dashboard) 
     - There is also a **Help** dropdown where you can find a link to this **Guide**, the **Sitemap** and **Restart**.
-4. The first time you visit, create a project so that you can immediately begin adding downloads.
+4. The first time you visit, create a project and make it active, so that you can immediately begin adding downloads.
 5. From the Open OnDemand dashboard, use the **Files > OnDemand Loop** menu item (or its configured location) to launch this app. When you’re done in Loop, click the **Open OnDemand** link in the navigation bar to go back to the dashboard.

--- a/docs/guide/content/user_guide/index.md
+++ b/docs/guide/content/user_guide/index.md
@@ -8,7 +8,7 @@ The project becomes the context for all actions performed through the user inter
 
 Each project has its own:
 
-- **Working directory** – where downloaded files are saved. This keeps files organized and isolated by project, making them easy to find and manage.
+- **Working directory** – where downloaded files are saved. This keeps files organized and separated by project, making them easy to find and manage.
 - **Metadata directory** – where the application stores internal data such as download history, upload collection definitions, and the Project’s current state. This allows OnDemand Loop to track progress, resume operations, and display status accurately.
 
 Having an active Project enables you to:
@@ -20,7 +20,7 @@ The interface is designed to guide you through these workflows with minimal setu
 
 !!! note
 
-    OnDemand Loop is **not a synchronization tool**. Instead, each **upload and download action is a discrete, immutable operation**.
+    OnDemand Loop is **not a synchronization tool**. Instead, each **upload and download action is a discrete operation**.
     This means that if files are changed in either the repository or the local HPC system, users must **manually re-download or re-upload** to ensure that the latest versions are captured.
     This design prioritizes simplicity, reproducibility, and clear audit trails over automated syncing.
 
@@ -35,6 +35,7 @@ Built‑in repository connectors handle the details of each repository’s API, 
 3. Familiarize yourself with the navigation bar:
     - **Projects**, **Downloads**, **Uploads**, and a **Repositories** drop-down appear from left to right.
     - The **Explore** link toggles a bar where you can paste a DOI or repository URL.
-    - On the far right you’ll see links to **Open OnDemand** (which returns you to the main dashboard) and **Restart**.
-4. The first time you visit, create project so that you can immediately begin adding downloads.
+    - On the far right you’ll see links to **Open OnDemand** (which returns you to the main dashboard) 
+    - There is also a **Help** dropdown where you can find a link to this **Guide**, the **Sitemap** and **Restart**.
+4. The first time you visit, create a project so that you can immediately begin adding downloads.
 5. From the Open OnDemand dashboard, use the **Files > OnDemand Loop** menu item (or its configured location) to launch this app. When you’re done in Loop, click the **Open OnDemand** link in the navigation bar to go back to the dashboard.

--- a/docs/guide/content/user_guide/projects.md
+++ b/docs/guide/content/user_guide/projects.md
@@ -33,7 +33,6 @@ You can also use projects for short-lived or ad-hoc tasks — such as quickly do
 
 Selecting a project opens its **detail page**, where you can:
 
-- **Edit project information** such as the name.
 - **Review the status of downloads and uploads**, including progress and completion history.
 - **Create upload bundles** linked to a specific remote dataset.
 - **Stage files for upload** by selecting local files from the HPC filesystem to include in a bundle.
@@ -52,7 +51,7 @@ Selecting a project opens its **detail page**, where you can:
 
 ### Project Folder Structure
 
-Each project has a dedicated location on the user space on the HPC filesystem with two main folders:
+Each project has a dedicated location on the user's space on the HPC filesystem with two main folders:
 
 #### Project Workspace Folder
 
@@ -61,7 +60,7 @@ This is the **working directory** for the project. It contains:
 - All downloaded files from remote repositories with the relevant path if provided by the repository
 - Subdirectories (if applicable) for organizing data by dataset or purpose
 
-You can open the project workspace folder from the project detail page.
+You can open the project workspace folder from the project detail page by clicking on the icon on the left of the project name.
 
 #### Metadata Folder
 
@@ -73,7 +72,7 @@ This folder stores internal files used by OnDemand Loop to manage the project st
 - Upload manifests
 
 The metadata folder is useful for debugging or inspecting the internal state of the application.
-You can open the project metadata directory directly from the project detail page.
+You can open the project metadata directory directly from the project detail page by clicking on the icon on the top-right.
 
 !!! note
 
@@ -81,9 +80,9 @@ You can open the project metadata directory directly from the project detail pag
     When you open a folder from the project detail page, it will launch the Files app in a new browser tab or window.  
     You can use it to move, rename, or inspect files directly on the cluster. When you're finished, close the window and return to the OnDemand Loop interface.
 
-<pre><code># Sample Application Folder Metadata Structure
+<pre><code># OnDemand LOOP Metadata Folder Structure
 
-metadata/
+.loop_metadata/
 ├── projects/
 │   └── experimental_processor_39/
 │       ├── download_files/
@@ -100,3 +99,4 @@ metadata/
 - Use projects to mirror your research structure (e.g., by topic, grant, or publication).
 - Create temporary projects for quick transfers or testing — you can delete them later without affecting stored data.
 - Keep your workspace tidy by removing old projects you no longer need.
+- Clean up files after deleting a project

--- a/docs/guide/content/user_guide/uploading_files.md
+++ b/docs/guide/content/user_guide/uploading_files.md
@@ -162,3 +162,11 @@ At the top of the global Uploads page, a summary panel displays the current syst
     Files cannot be deleted directly from the global **Uploads** page. 
     To remove a file, go to the corresponding project and use the **Delete** action inside the appropriate upload bundle.
     Click the project name to jump directly to its Upload Bundles tab.
+
+### Checksum verification
+
+A checksum verification is done after each file is uploaded to **Dataverse**. In case of invalid verification, `error` state
+will be displayed for that file despite being transferred entirely. Uploads checksum verification will be implemented for
+other connectors like **Zenodo** in the future.
+
+---

--- a/docs/guide/content/user_guide/uploading_files.md
+++ b/docs/guide/content/user_guide/uploading_files.md
@@ -17,15 +17,14 @@ Uploads are organized into **Upload Bundles**, which group a set of files and li
     - Click the **pencil icon** to enter your key and choose whether to save it globally or only for this bundle.
 
 3. **Select or Create a Dataset**  
-   Depending on the type of URL provided and the rules of the remote repository,  
-   additional steps may be required before files can be uploaded.
+   Depending on the type of URL provided and the rules of the remote repository, additional steps may be required before files can be uploaded.
 
    The interface will guide you through any necessary actions to fully configure the dataset destination.  
    These actions may include:
 
-    - Selecting a dataset from within a collection
-    - Creating a new dataset if required or desired
-    - Fetching additional metadata from the repository
+   - Selecting a dataset from within a collection
+   - Creating a new dataset if required or desired
+   - Fetching additional metadata from the repository
 
    Once these steps are complete, the upload bundle is linked to the appropriate dataset and ready for file staging.
 

--- a/docs/guide/content/user_guide/uploading_files.md
+++ b/docs/guide/content/user_guide/uploading_files.md
@@ -17,14 +17,11 @@ Uploads are organized into **Upload Bundles**, which group a set of files and li
     - Click the **pencil icon** to enter your key and choose whether to save it globally or only for this bundle.
 
 3. **Select or Create a Dataset**  
-   Depending on the type of URL provided and the rules of the remote repository, additional steps may be required before files can be uploaded.
-
-   The interface will guide you through any necessary actions to fully configure the dataset destination.  
+   Depending on the type of URL provided and the rules of the remote repository, additional steps may be required before files can be uploaded. The interface will guide you through any necessary actions to fully configure the dataset destination.
    These actions may include:
-
-   - Selecting a dataset from within a collection
-   - Creating a new dataset if required or desired
-   - Fetching additional metadata from the repository
+    - Selecting a dataset from within a collection
+    - Creating a new dataset if required or desired
+    - Fetching additional metadata from the repository
 
    Once these steps are complete, the upload bundle is linked to the appropriate dataset and ready for file staging.
 
@@ -33,13 +30,12 @@ Uploads are organized into **Upload Bundles**, which group a set of files and li
    Use this interface to navigate your HPC project directory and select the files to be uploaded.
    For help using the Upload File Selector, see [Upload File Selector](./upload_file_selector.md).
 
-   Once selected, files are automatically staged and uploaded. You can monitor progress in the bundle view or the global **Uploads** page.  
-   Upload tasks can be cancelled before or during transfer.s
+   Once selected, files are automatically staged and uploaded. You can monitor progress in the bundle view or the global **Uploads** page.
+   Upload tasks can be cancelled before or during transfers.
 
 !!! note
 
-    This view does **not auto-refresh**. Reload the page manually to see updated statuses.
-
+    The file list in the **Upload Bundle** view does **not auto-refresh**. Reload the page manually to see updated statuses.
 ---
 
 ### Creating an Upload Bundle


### PR DESCRIPTION
## Description
This PR address the review suggestions provided by Bill:

- In the User Guide:
  - Introduction page:
    - It says that the Working directory keeps files "isolated." I think this term is too strong and inaccurate since the files are not in isolation but are grouped into projects. I suggest changing this to "separated."
    - It says that each "upload and download action is a discrete, immutable operation." I suggest removing the word "immutable" as a descriptor of upload and download operations since it is not accurate. An upload or download operation can be mutated through cancellation, and I think the mention of mutability distracts from the point that files are not synchronized.
    - It describes the spatial layout of the top navigation elements. However, the description is not correct. The "Restart" link is now under a "Help" menu along with a "Guide" link. Also, if the viewport width is narrowed the spatial layout changes dramatically and no longer matches the description. Lastly, the "up" and "down" arrows are not described, and I found them to be the most confusing and unintuitive element of the UI until I read the hover text.
    - "The first time you visit, create project" should be "The first time you visit, create a project"
  - Projects page:
    - Says that "Selecting a project opens its detail page, where you can... Edit project information such as the name." This is not true in the current production UI; the project name cannot be edited from the project detail page, only the project overview page.
    - "Each project has a dedicated location on the user space on the HPC filesystem" should be "Each project has a dedicated location in the user's space on the HPC filesystem".
    - Says "You can open the project workspace folder from the project detail page." and uses the term "Project Workspace folder" repeatedly, but hover text on the linked icon in the UI identifies it as the "project folder." I believe that using the term "project workspace folder" would be clearer in the UI.
    - I was confused initially about where to find the folder links in the UI, and which one was which, especially since there is another folder link on that page that is not described here (the Downloads folder link). It would be helpful to provide either a spatial reference in text (e.g. "on the left/right") or a visual cross-reference (e.g. a copy of the icon or a screenshot).
    - Labels a textual diagram as "Sample Application Folder Metadata Structure". This label makes no sense to me. Should it be "OnDemand LOOP Metadata Folder Structure"?
    - When I browsed the metadata folder, it was named `.downloads-for-ondemand` (not `metadata` as shown in the diagram) and it only contained a `projects` directory and none of the other indicated contents.
    - I suggest to add another Best Practice: "Clean up files after deleting a project."
  - Finding Data page
    - The documentation here for "Browse and Search Within OnDemand Loop" is accurate but I found the UI confusing. After clicking "Dataverse" I expected to be able to search all dataverse repositories, but my dataset query turned up no results. Only after re-reading the docs did I realize that the first search box is to search for an installation, and that an installation must be selected before a dataset search can be performed. Selecting separate vertical search engines is an awkward UX. I would have been better served if the documentation made this clearer.
  - Downloads page
    - Describes what happens when there is no Active Project: each time you select files to add to the download queue, it creates a new project and downloads them there. This does not seem like a useful UX. The main problem with this UX flow is that if you just start using LOOP out of the box to download files each file ends up going into a separate project in a random download location and it is not clear why. Firstly, I would expect that if a new project is created when no project is currently active that the new project would be set active (and this would be documented on the Projects page). Secondly, the UI says "Add Files to Active Project", which implied that there is an Active Project even when there was not, so I did not expect that a new project would be created and that the files would be downloaded to a new random location, especially the second time, after it had already created a project for download. Unless the app logic is changed so that there is always an Active Project (e.g by auto-Activating on project creation if there is no current Active project), I suggest changing the UI so that the button accurately reflects what it is going to do -- i.e. instead of "Add files to Active Project" it would be "Add files to New Project."
    - Describes the Project Detail Page – Downloads Tab as having Metadata Fields showing e.g. the Filename. I went looking for this in the current prod UI and could not find it at first because I was looking on the Projects page and not the Project Detail page. I was convinced that was the correct page because it had a Downloads Tab as described in the docs, but the Downloads Tab there only lists a summary. I was also confused that the Download Tab itself was clickable but went nowhere -- I thought it might take me to the detail list I was looking for.
    - Describes the Global Downloads Page as having different Status Summary Counters than the Project Detail Page – Downloads Tab. This is true, but why? It makes the UX more confusing. Why no "Error" count on the global page and no "In Progress" count on the project detail download tab?
    - Says that "Files are queued when system resources are busy..." and doesn't define "busy". I think this might should be "Files are queued when a download is already in progress..."
    - For the number of times I found myself visiting the Project Detail pages from the Project page, I found their clickable target areas to be small and surrounded by other less-used clickable elements. I would prefer them to be easier to target.
    - Does not mention checksum verification, which is mentioned briefly on the Supported Repositories page. Please enhance the Downloads page to describe when checksum verification occurs, and how it is indicated in the UI: firstly, whether or not checksum verification was performed, and secondly, whether or not it succeeded.
  - Uploads page
    - I was unable to confirm that this functionality matches the docs since I do not have an API key for an upload destination.
    - In "Depending on the type of URL provided and the rules of the remote repository, additional steps may be required before files can be uploaded." there is a spurious linebreak after the comma.
    - Under "Select or Create a Dataset" a preformatted block is used for what should be an unordered list of items.
  - Upload File Selector page
    - I was unable to confirm that this functionality matches the docs since I do not have an API key for an upload destination.
  - Supported Repositories page
    - Looks fine other than the sole mention of checksums which I referred back to the Downloading Files page.
   
## Related Issue
this is related to https://github.com/IQSS/ondemand-loop/issues/242

## Changes Made
- changes in the documentation
- some issues were created to address pending comments in separate PRs

## Testing
- [ ] Added/updated tests
- [ ] All tests pass locally
- [ ] Tested manually (describe how)

## Documentation
- [x] Updated relevant documentation
- [ ] No documentation changes needed