### PR TITLE
fix: Updated DataverseHub URL after server update

### DIFF
--- a/application/app/services/dataverse/dataverse_hub.rb
+++ b/application/app/services/dataverse/dataverse_hub.rb
@@ -2,7 +2,7 @@ module Dataverse
   class DataverseHub
     include LoggingCommon
     DEFAULT_CACHE_EXPIRY = 24.hours.freeze
-    HUB_API_URL = 'https://hub.dataverse.org/api/installation'
+    HUB_API_URL = 'https://hub.dataverse.org/api/installations'
 
     def initialize(
       url: HUB_API_URL,
@@ -46,11 +46,14 @@ module Dataverse
             id: entry['dvHubId'],
             name: entry['name'],
             hostname: entry['hostname'],
+            active: entry.fetch('isActive', true),
           }
         end.compact
 
-        log_info('Completed loading Dataverse installations', {servers: installations.size})
-        installations
+        active, inactive = installations.partition { |item| item[:active] }
+
+        log_info('Completed loading Dataverse installations', {active: active.size, inactive: inactive.size})
+        active
       else
         log_error('Failed to fetch Dataverse Hub data', {url: @url, response: response.status}, nil)
         []

--- a/application/test/services/dataverse/dataverse_hub_test.rb
+++ b/application/test/services/dataverse/dataverse_hub_test.rb
@@ -5,7 +5,7 @@ require 'test_helper'
 class Dataverse::DataverseHubTest < ActiveSupport::TestCase
   include ActiveSupport::Testing::TimeHelpers
 
-  TEST_URL = 'https://my.hub.com/api/installation'
+  TEST_URL = 'https://my.hub.com/api/installations'
 
   setup do
     @mock_client = mock('HttpClient')
@@ -21,10 +21,11 @@ class Dataverse::DataverseHubTest < ActiveSupport::TestCase
     travel_back
   end
 
-  test 'installations fetches and stores non-empty results' do
+  test 'installations fetches and stores non-empty results filtering inactive' do
     response_data = [
-      { 'dvHubId' => 'dv1', 'name' => 'DV One', 'hostname' => 'dv1.org' },
-      { 'dvHubId' => 'dv2', 'name' => 'DV Two', 'hostname' => 'dv2.org' }
+      { 'dvHubId' => 'dv1', 'name' => 'DV One', 'hostname' => 'dv1.org', 'isActive' => true },
+      { 'dvHubId' => 'dv2', 'name' => 'DV Two', 'hostname' => 'dv2.org', 'isActive' => true  },
+      { 'dvHubId' => 'dv3', 'name' => 'DV Two', 'hostname' => 'dv2.org', 'isActive' => false  }
     ]
     response = stub(success?: true, body: response_data.to_json)
 
@@ -37,7 +38,7 @@ class Dataverse::DataverseHubTest < ActiveSupport::TestCase
     assert_equal 'dv2', result.last[:id]
   end
 
-  test 'installations returns stored data without refetching if not expired' do
+  test 'installations returns stored data without re-fetching if not expired' do
     response_data = [
       { 'dvHubId' => 'dv-stored', 'name' => 'Stored DV', 'hostname' => 'stored.org' }
     ]


### PR DESCRIPTION
## Description
Update DataverseHub URL as the server has chaged

## Related Issue
Fixes #305 

## Changes Made
- DataverseHub URL update

## Testing
- [x] Added/updated tests
- [x] All tests pass locally
- [x] Tested manually (describe how)

## Documentation
- [ ] Updated relevant documentation
- [x] No documentation changes needed