### PR TITLE
feat: Added Repository Explore landing page support

### DIFF
--- a/application/app/connectors/dataverse/explore_connector_processor.rb
+++ b/application/app/connectors/dataverse/explore_connector_processor.rb
@@ -24,5 +24,13 @@ module Dataverse
         success: true
       )
     end
+
+    def landing(request_params)
+      ConnectorResult.new(
+        template: '/connectors/dataverse/explore_placeholder',
+        locals: { data: request_params },
+        success: true
+      )
+    end
   end
 end

--- a/application/app/connectors/zenodo/explore_connector_processor.rb
+++ b/application/app/connectors/zenodo/explore_connector_processor.rb
@@ -27,5 +27,12 @@ module Zenodo
       action = ConnectorActionDispatcher.load(request_params[:connector_type], action_type, object_id)
       action.create(request_params)
     end
+
+    def landing(_request_params)
+      ConnectorResult.new(
+        message: { alert: I18n.t('connectors.zenodo.actions.landing.message_action_not_supported') },
+        success: false
+      )
+    end
   end
 end

--- a/application/config/locales/connectors/zenodo/en.yml
+++ b/application/config/locales/connectors/zenodo/en.yml
@@ -6,6 +6,8 @@ en:
       aria_label: "Visit the Zenodo project homepage"
 
       actions:
+        landing:
+          message_action_not_supported: "Action not supported"
         connector_edit:
           message_success: "Access token updated: %{name}"
         fetch_deposition:

--- a/application/config/locales/controllers/en.yml
+++ b/application/config/locales/controllers/en.yml
@@ -68,3 +68,5 @@ en:
     create:
       message_invalid_repo_url: "Invalid repository URL: %{repo_url}"
       message_processor_error: "Error processing request for repository: %{connector_type} type: %{object_type} with id: %{object_id}"
+    landing:
+      message_processor_error: "Error processing request for repository: %{connector_type}"

--- a/application/config/routes.rb
+++ b/application/config/routes.rb
@@ -60,6 +60,7 @@ Rails.application.routes.draw do
   get "/view/dataverse/*dv_hostname/dataverses/:id" => "dataverse/collections#show", as: :view_dataverse, format: false
 
   # EXPLORE ROUTE
+  get "/explore/:connector_type/landing" => "explore#landing", as: :explore_landing
   get "/explore/:connector_type/*server_domain/:object_type/:object_id" => "explore#show", as: :explore
   post "/explore/:connector_type/*server_domain/:object_type/:object_id" => "explore#create"
 

--- a/application/test/controllers/explore_controller_test.rb
+++ b/application/test/controllers/explore_controller_test.rb
@@ -13,24 +13,14 @@ class ExploreControllerTest < ActionDispatch::IntegrationTest
     assert_select 'div.alert-info'
   end
 
-  test 'zenodo landing action delegates to search service' do
-    service = mock
-    service.expects(:search)
-           .with('test', page: 1)
-           .returns(OpenStruct.new(items: []))
-    Zenodo::SearchService.expects(:new)
-                          .with('https://zenodo.org')
-                          .returns(service)
-
-    get explore_url(
+  test 'zenodo landing action is not supported' do
+    get explore_landing_url(
       connector_type: 'zenodo',
-      server_domain: 'zenodo.org',
-      object_type: 'actions',
-      object_id: 'landing',
       query: 'test'
     )
 
-    assert_response :success
+    assert_redirected_to root_path
+    assert_equal I18n.t('connectors.zenodo.actions.landing.message_action_not_supported'), flash[:alert]
   end
 
   test 'redirects when repo url is invalid' do

--- a/application/test/controllers/explore_controller_test.rb
+++ b/application/test/controllers/explore_controller_test.rb
@@ -1,78 +1,75 @@
 require "test_helper"
 
 class ExploreControllerTest < ActionDispatch::IntegrationTest
-  test 'should render placeholder template with notice' do
+  def stub_processor(action, result)
+    processor = mock("ExploreProcessor")
+    processor.stubs(:params_schema).returns(%i[connector_type server_domain object_type object_id query server_scheme server_port])
+    processor.expects(action).with(kind_of(Hash)).returns(result)
+    ConnectorClassDispatcher.stubs(:explore_connector_processor).returns(processor)
+  end
+
+  test "landing action renders template when processor succeeds" do
+    stub_processor(:landing, ConnectorResult.new(template: "/sitemap/index", locals: {}, success: true))
+
+    get explore_landing_url(connector_type: "zenodo")
+
+    assert_response :success
+  end
+
+  test "landing action redirects with message when processor fails" do
+    stub_processor(:landing, ConnectorResult.new(message: { alert: "error" }, success: false))
+
+    get explore_landing_url(connector_type: "zenodo")
+
+    assert_redirected_to root_path
+    assert_equal "error", flash[:alert]
+  end
+
+  test "redirects when repo url is invalid" do
+    get "/explore/zenodo/%20/records/1"
+
+    assert_redirected_to root_path
+    assert_equal I18n.t("explore.show.message_invalid_repo_url", repo_url: ""), flash[:alert]
+  end
+
+  test "show action renders template when processor succeeds" do
+    stub_processor(:show, ConnectorResult.new(template: "/sitemap/index", locals: {}, success: true))
+
     get explore_url(
-      connector_type: 'dataverse',
-      server_domain: 'dataverse.harvard.edu',
-      object_type: 'dataverse',
-      object_id: 'harvard'
+      connector_type: "zenodo",
+      server_domain: "example.org",
+      object_type: "records",
+      object_id: "1"
     )
 
     assert_response :success
-    assert_select 'div.alert-info'
   end
 
-  test 'zenodo landing action is not supported' do
-    get explore_landing_url(
-      connector_type: 'zenodo',
-      query: 'test'
-    )
-
-    assert_redirected_to root_path
-    assert_equal I18n.t('connectors.zenodo.actions.landing.message_action_not_supported'), flash[:alert]
-  end
-
-  test 'redirects when repo url is invalid' do
-    get '/explore/zenodo/%20/actions/landing'
-
-    assert_redirected_to root_path
-    assert_equal I18n.t('explore.show.message_invalid_repo_url', repo_url: ''), flash[:alert]
-  end
-
-  test 'zenodo records action renders record view' do
-    record = Struct.new(:id, :title, :description, :publication_date, :files) do
-      def draft?
-        false
-      end
-    end.new('1', 'rec', '', '', [])
-    Zenodo::RecordService.any_instance.expects(:find_record).with('1').returns(record)
-    user_settings_mock = mock('UserSettings')
-    user_settings_mock.stubs(:user_settings).returns(OpenStruct.new(active_project: nil))
-    Current.stubs(:settings).returns(user_settings_mock)
+  test "show action redirects with message when processor fails" do
+    stub_processor(:show, ConnectorResult.new(message: { alert: "error" }, success: false))
 
     get explore_url(
-      connector_type: 'zenodo',
-      server_domain: 'zenodo.org',
-      object_type: 'records',
-      object_id: '1'
+      connector_type: "zenodo",
+      server_domain: "example.org",
+      object_type: "records",
+      object_id: "1"
     )
 
-    assert_response :success
-    assert_select 'h2', text: 'rec'
+    assert_redirected_to root_path
+    assert_equal "error", flash[:alert]
   end
 
-  test 'zenodo records download redirects with notice' do
-    record = Struct.new(:id, :title, :description, :publication_date, :files) do
-      def draft?
-        false
-      end
-    end.new('1', 'rec', '', '', [])
-    Zenodo::RecordService.any_instance.stubs(:find_record).returns(record)
-    Project.stubs(:find).returns(nil)
-    project = Project.new(name: 'P')
-    project.stubs(:save).returns(true)
-    Zenodo::ProjectService.any_instance.stubs(:initialize_project).returns(project)
-    Zenodo::ProjectService.any_instance.stubs(:create_files_from_record).returns([])
+  test "create action redirects with message from processor" do
+    stub_processor(:create, ConnectorResult.new(message: { notice: "ok" }, success: true))
 
     post explore_url(
-      connector_type: 'zenodo',
-      server_domain: 'zenodo.org',
-      object_type: 'records',
-      object_id: '1'
+      connector_type: "zenodo",
+      server_domain: "example.org",
+      object_type: "records",
+      object_id: "1"
     )
 
     assert_redirected_to root_path
-    assert_equal I18n.t('zenodo.records.message_success', files: 0, project_name: 'P'), flash[:notice]
+    assert_equal "ok", flash[:notice]
   end
 end

--- a/application/test/controllers/explore_controller_test.rb
+++ b/application/test/controllers/explore_controller_test.rb
@@ -1,75 +1,115 @@
-require "test_helper"
+require 'test_helper'
 
 class ExploreControllerTest < ActionDispatch::IntegrationTest
-  def stub_processor(action, result)
-    processor = mock("ExploreProcessor")
+  def stub_processor(action, result: nil, exception: nil)
+    processor = mock('ExploreProcessor')
     processor.stubs(:params_schema).returns(%i[connector_type server_domain object_type object_id query server_scheme server_port])
-    processor.expects(action).with(kind_of(Hash)).returns(result)
+    expectation = processor.expects(action).with(kind_of(Hash))
+    expectation.returns(result) if result
+    expectation.raises(exception) if exception
     ConnectorClassDispatcher.stubs(:explore_connector_processor).returns(processor)
   end
 
-  test "landing action renders template when processor succeeds" do
-    stub_processor(:landing, ConnectorResult.new(template: "/sitemap/index", locals: {}, success: true))
+  test 'landing action renders template when processor succeeds' do
+    stub_processor(:landing, result: ConnectorResult.new(template: '/sitemap/index', locals: {}, success: true))
 
-    get explore_landing_url(connector_type: "zenodo")
+    get explore_landing_url(connector_type: 'zenodo')
 
     assert_response :success
   end
 
-  test "landing action redirects with message when processor fails" do
-    stub_processor(:landing, ConnectorResult.new(message: { alert: "error" }, success: false))
+  test 'landing action redirects with message when processor fails' do
+    stub_processor(:landing, result: ConnectorResult.new(message: { alert: 'error' }, success: false))
 
-    get explore_landing_url(connector_type: "zenodo")
-
-    assert_redirected_to root_path
-    assert_equal "error", flash[:alert]
-  end
-
-  test "redirects when repo url is invalid" do
-    get "/explore/zenodo/%20/records/1"
+    get explore_landing_url(connector_type: 'zenodo')
 
     assert_redirected_to root_path
-    assert_equal I18n.t("explore.show.message_invalid_repo_url", repo_url: ""), flash[:alert]
+    assert_equal 'error', flash[:alert]
   end
 
-  test "show action renders template when processor succeeds" do
-    stub_processor(:show, ConnectorResult.new(template: "/sitemap/index", locals: {}, success: true))
+  test 'landing action redirects with error message when processor raises' do
+    stub_processor(:landing, exception: StandardError.new('boom'))
+
+    get explore_landing_url(connector_type: 'zenodo')
+
+    assert_redirected_to root_path
+    assert_equal I18n.t('explore.landing.message_processor_error', connector_type: 'zenodo'), flash[:alert]
+  end
+
+  test 'redirects when repo url is invalid' do
+    get '/explore/zenodo/%20/records/1'
+
+    assert_redirected_to root_path
+    assert_equal I18n.t('explore.show.message_invalid_repo_url', repo_url: ''), flash[:alert]
+  end
+
+  test 'show action renders template when processor succeeds' do
+    stub_processor(:show, result: ConnectorResult.new(template: '/sitemap/index', locals: {}, success: true))
 
     get explore_url(
-      connector_type: "zenodo",
-      server_domain: "example.org",
-      object_type: "records",
-      object_id: "1"
+      connector_type: 'zenodo',
+      server_domain: 'example.org',
+      object_type: 'records',
+      object_id: '1',
     )
 
     assert_response :success
   end
 
-  test "show action redirects with message when processor fails" do
-    stub_processor(:show, ConnectorResult.new(message: { alert: "error" }, success: false))
+  test 'show action redirects with message when processor fails' do
+    stub_processor(:show, result: ConnectorResult.new(message: { alert: 'error' }, success: false))
 
     get explore_url(
-      connector_type: "zenodo",
-      server_domain: "example.org",
-      object_type: "records",
-      object_id: "1"
+      connector_type: 'zenodo',
+      server_domain: 'example.org',
+      object_type: 'records',
+      object_id: '1',
     )
 
     assert_redirected_to root_path
-    assert_equal "error", flash[:alert]
+    assert_equal 'error', flash[:alert]
   end
 
-  test "create action redirects with message from processor" do
-    stub_processor(:create, ConnectorResult.new(message: { notice: "ok" }, success: true))
+  test 'show action redirects with error message when processor raises' do
+    stub_processor(:show, exception: StandardError.new('boom'))
+
+    get explore_url(
+      connector_type: 'zenodo',
+      server_domain: 'example.org',
+      object_type: 'records',
+      object_id: '1',
+    )
+
+    assert_redirected_to root_path
+    assert_equal I18n.t('explore.show.message_processor_error', connector_type: 'zenodo', object_type: 'records', object_id: '1'), flash[:alert]
+  end
+
+  test 'create action redirects with message from processor' do
+    stub_processor(:create, result: ConnectorResult.new(message: { notice: 'ok' }, success: true))
 
     post explore_url(
-      connector_type: "zenodo",
-      server_domain: "example.org",
-      object_type: "records",
-      object_id: "1"
+      connector_type: 'zenodo',
+      server_domain: 'example.org',
+      object_type: 'records',
+      object_id: '1',
     )
 
     assert_redirected_to root_path
-    assert_equal "ok", flash[:notice]
+    assert_equal 'ok', flash[:notice]
+  end
+
+  test 'create action redirects with error message when processor raises' do
+    stub_processor(:create, exception: StandardError.new('boom'))
+
+    post explore_url(
+      connector_type: 'zenodo',
+      server_domain: 'example.org',
+      object_type: 'records',
+      object_id: '1',
+    )
+
+    assert_redirected_to root_path
+    assert_equal I18n.t('explore.create.message_processor_error', connector_type: 'zenodo', object_type: 'records', object_id: '1'), flash[:alert]
   end
 end
+


### PR DESCRIPTION
## Description
Added Repository Explore landing page support.

This is to support adding a landing page for a connector to put generic info and widgets.


## Testing
- [ ] Added/updated tests
- [ ] All tests pass locally
- [x] Tested manually (describe how)

## Documentation
- [ ] Updated relevant documentation
- [x] No documentation changes needed