### PR TITLE
feat: Added Zenodo DOI resolver

### DIFF
--- a/application/app/services/repo/resolvers/zenodo_doi_resolver.rb
+++ b/application/app/services/repo/resolvers/zenodo_doi_resolver.rb
@@ -1,0 +1,35 @@
+# frozen_string_literal: true
+
+module Repo
+  module Resolvers
+    class ZenodoDoiResolver < Repo::BaseResolver
+      include LoggingCommon
+
+      def self.build
+        new
+      end
+
+      # Run after ZenodoResolver
+      def priority
+        8_500
+      end
+
+      def resolve(context)
+        return unless context.object_url
+        return unless context.type&.zenodo?
+
+        zenodo_url = Zenodo::ZenodoUrl.parse(context.object_url)
+        return unless zenodo_url&.doi?
+
+        response = context.http_client.head(context.object_url)
+        if response.redirect?
+          new_url = response.location
+          log_info('Zenodo DOI resolved', { doi_url: context.object_url, object_url: new_url })
+          context.object_url = new_url
+        else
+          log_info('Unable to resolve Zenodo DOI', { doi_url: context.object_url, response: response.status })
+        end
+      end
+    end
+  end
+end

--- a/application/test/services/repo/resolvers/zenodo_doi_resolver_test.rb
+++ b/application/test/services/repo/resolvers/zenodo_doi_resolver_test.rb
@@ -1,0 +1,46 @@
+require 'test_helper'
+
+class Repo::Resolvers::ZenodoDoiResolverTest < ActiveSupport::TestCase
+  include LoggingCommonMock
+
+  test 'resolve updates object_url on redirect' do
+    client = HttpClientMock.new(file_path: fixture_path('downloads/basic_http/sample_utf8.txt'),
+                                 status_code: 302,
+                                 headers: { 'location' => 'https://zenodo.org/records/16764341' })
+    context = Repo::RepoResolverContext.new('https://zenodo.org/doi/10.5281/zenodo.16764341', http_client: client)
+    context.object_url = 'https://zenodo.org/doi/10.5281/zenodo.16764341'
+    context.type = ConnectorType::ZENODO
+
+    resolver = Repo::Resolvers::ZenodoDoiResolver.new
+    resolver.resolve(context)
+
+    assert client.called?
+    assert_equal 'https://zenodo.org/records/16764341', context.object_url
+  end
+
+  test 'resolve leaves object_url when DOI has no redirect' do
+    client = HttpClientMock.new(file_path: fixture_path('downloads/basic_http/sample_utf8.txt'))
+    context = Repo::RepoResolverContext.new('https://zenodo.org/doi/10.5281/zenodo.16764341', http_client: client)
+    context.object_url = 'https://zenodo.org/doi/10.5281/zenodo.16764341'
+    context.type = ConnectorType::ZENODO
+
+    resolver = Repo::Resolvers::ZenodoDoiResolver.new
+    resolver.resolve(context)
+
+    assert client.called?
+    assert_equal 'https://zenodo.org/doi/10.5281/zenodo.16764341', context.object_url
+  end
+
+  test 'resolve is no-op when object_url is not a DOI' do
+    client = HttpClientMock.new(file_path: fixture_path('downloads/basic_http/sample_utf8.txt'))
+    context = Repo::RepoResolverContext.new('https://zenodo.org/records/16764341', http_client: client)
+    context.object_url = 'https://zenodo.org/records/16764341'
+    context.type = ConnectorType::ZENODO
+
+    resolver = Repo::Resolvers::ZenodoDoiResolver.new
+    resolver.resolve(context)
+
+    assert_not client.called?
+    assert_equal 'https://zenodo.org/records/16764341', context.object_url
+  end
+end


### PR DESCRIPTION
## Description
DOIs from Zenodo records resolve to a intermediate redirect like: https://zenodo.org/doi/10.5281/zenodo.16764341
This resolver will check and update to the final Zenodo URL


## Testing
- [x] Added/updated tests
- [x] All tests pass locally
- [ ] Tested manually (describe how)

## Documentation
- [ ] Updated relevant documentation
- [x] No documentation changes needed