### PR TITLE
feat: Added support for redirects in ConnectorResponse

### DIFF
--- a/application/app/connectors/connector_result.rb
+++ b/application/app/connectors/connector_result.rb
@@ -23,6 +23,14 @@ class ConnectorResult
     data[:redirect_url]
   end
 
+  def redirect?
+    redirect_url.present?
+  end
+
+  def redirect_back?
+    data[:redirect_back] == true
+  end
+
   def template
     data[:template]
   end

--- a/application/app/controllers/concerns/connector_response.rb
+++ b/application/app/controllers/concerns/connector_response.rb
@@ -4,7 +4,11 @@ module ConnectorResponse
   private
 
   def respond_success(result)
-    if ajax_request?
+    if result.redirect?
+      redirect_to result.redirect_url, **result.message
+    elsif result.redirect_back?
+      redirect_back fallback_location: root_path, **result.message
+    elsif ajax_request?
       render partial: result.template, locals: result.locals, layout: false
     else
       render template: result.template, locals: result.locals

--- a/application/test/connectors/connector_result_test.rb
+++ b/application/test/connectors/connector_result_test.rb
@@ -6,11 +6,18 @@ class ConnectorResultTest < ActiveSupport::TestCase
     assert_equal '/path', result.redirect_url
     assert_equal({notice: 'ok'}, result.message)
     assert result.success?
+    assert result.redirect?
     assert_equal({redirect_url: '/path', message: {notice: 'ok'}}, result.to_h)
   end
 
   test 'success? false when success field set to false' do
     result = ConnectorResult.new(success: false)
     refute result.success?
+  end
+
+  test 'redirect_back flag helper' do
+    result = ConnectorResult.new(redirect_back: true)
+    assert result.redirect_back?
+    refute result.redirect?
   end
 end


### PR DESCRIPTION
## Description
Added support for redirects in ConnectorResponse.

This is required to implement Dataverse External Tools integration

## Related Issue
Fixes #[issue-number]

## Testing
- [ ] Added/updated tests
- [ ] All tests pass locally
- [ ] Tested manually (describe how)

## Documentation
- [ ] Updated relevant documentation
- [ ] No documentation changes needed