### PR TITLE
fix: Created ConnectorResolver to fix repo validation

### DIFF
--- a/application/app/controllers/concerns/connector_resolver.rb
+++ b/application/app/controllers/concerns/connector_resolver.rb
@@ -1,0 +1,39 @@
+# frozen_string_literal: true
+
+# Concern with helper methods for controllers that resolve connectors and
+# repository URLs. It parses the connector type from params, builds a repo URL
+# from request parameters, and validates the resolved repository type against
+# the connector type.
+
+module ConnectorResolver
+  extend ActiveSupport::Concern
+
+  private
+
+  def parse_connector_type
+    @connector_type = ConnectorType.get(params[:connector_type])
+  rescue ArgumentError => e
+    log_error('Invalid connector type', { connector_type: params[:connector_type] }, e)
+    redirect_to root_path, alert: I18n.t('connector_resolver.message_invalid_connector_type', connector_type: params[:connector_type])
+  end
+
+  def build_repo_url
+    @repo_url = Repo::RepoUrl.build(
+      params[:server_domain],
+      scheme: params[:server_scheme],
+      port: params[:server_port]
+    )
+
+    if @repo_url.nil?
+      redirect_to root_path, alert: I18n.t('connector_resolver.message_invalid_repo_url', repo_url: '')
+    end
+  end
+
+  def validate_repo_url
+    repo_resolver = Repo::RepoResolverService.new(RepoRegistry.resolvers)
+    resolution = repo_resolver.resolve(@repo_url.to_s)
+    if resolution.type != @connector_type
+      redirect_to root_path, alert: I18n.t('connector_resolver.message_invalid_repo_url', repo_url: @repo_url.to_s)
+    end
+  end
+end

--- a/application/app/controllers/concerns/connector_response.rb
+++ b/application/app/controllers/concerns/connector_response.rb
@@ -27,11 +27,4 @@ module ConnectorResponse
   def apply_flash_now(message_hash)
     (message_hash || {}).each { |k, v| flash.now[k] = v }
   end
-
-  def parse_connector_type
-    @connector_type = ConnectorType.get(params[:connector_type])
-  rescue ArgumentError => e
-    log_error('Invalid connector type', { connector_type: params[:connector_type] }, e)
-    redirect_to root_path, alert: I18n.t("#{controller_name}.message_invalid_connector_type", connector_type: params[:connector_type])
-  end
 end

--- a/application/app/controllers/connect_controller.rb
+++ b/application/app/controllers/connect_controller.rb
@@ -1,6 +1,7 @@
 class ConnectController < ApplicationController
   include LoggingCommon
   include ConnectorResponse
+  include ConnectorResolver
 
   before_action :parse_connector_type
 

--- a/application/app/controllers/explore_controller.rb
+++ b/application/app/controllers/explore_controller.rb
@@ -1,9 +1,11 @@
 class ExploreController < ApplicationController
   include LoggingCommon
   include ConnectorResponse
+  include ConnectorResolver
 
   before_action :parse_connector_type
   before_action :build_repo_url, only: %i[show create]
+  before_action :validate_repo_url, only: %i[show create]
 
   def show
     handler = ConnectorHandlerDispatcher.handler(@connector_type, params[:object_type], params[:object_id])
@@ -32,26 +34,5 @@ class ExploreController < ApplicationController
   rescue => e
     log_error('Error processing Explore.create handler/action', { connector_type: @connector_type, object_type: params[:object_type], object_id: params[:object_id] }, e)
     return redirect_back fallback_location: root_path, alert: I18n.t('explore.create.message_processor_error', connector_type: @connector_type, object_type: params[:object_type], object_id: params[:object_id])
-  end
-
-  private
-
-  def build_repo_url
-    @repo_url = Repo::RepoUrl.build(
-      params[:server_domain],
-      scheme: params[:server_scheme],
-      port: params[:server_port]
-    )
-
-    if @repo_url.nil?
-      redirect_to root_path, alert: I18n.t("explore.#{action_name}.message_invalid_repo_url", repo_url: '')
-      return
-    end
-
-    repo_info = RepoRegistry.repo_db.get(@repo_url.server_url)
-    if repo_info.nil? || repo_info.type != @connector_type
-      redirect_to root_path, alert: I18n.t("explore.#{action_name}.message_invalid_repo_url", repo_url: @repo_url.to_s)
-      return
-    end
   end
 end

--- a/application/config/locales/controllers/en.yml
+++ b/application/config/locales/controllers/en.yml
@@ -59,17 +59,17 @@ en:
     cancel:
       file_not_found: "file not found project_id=%{project_id} upload_bundle_id=%{upload_bundle_id} id=%{file_id}"
   explore:
-    message_invalid_connector_type: "Invalid connector type: %{connector_type}"
     show:
-      message_invalid_repo_url: "The repository URL %{repo_url} is not verified. For security reasons, only trusted repositories already registered in the system can be used"
       message_processor_error: "Error processing request for repository: %{connector_type} type: %{object_type} with id: %{object_id}"
     create:
-      message_invalid_repo_url: "The repository URL %{repo_url} is not verified. For security reasons, only trusted repositories already registered in the system can be used"
       message_processor_error: "Error processing request for repository: %{connector_type} type: %{object_type} with id: %{object_id}"
 
   connect:
     show:
       message_processor_error: "Error processing request for repository: %{connector_type} action: %{action}"
-    message_invalid_connector_type: "Invalid connector type: %{connector_type}"
     handle:
       message_processor_error: "Error processing request for repository: %{connector_type} action: %{action}"
+
+  connector_resolver:
+    message_invalid_connector_type: "Invalid connector type: %{connector_type}"
+    message_invalid_repo_url: "The repository URL %{repo_url} is not verified. For security reasons, only trusted repositories already registered in the system can be used"

--- a/application/test/controllers/concerns/connector_resolver_test.rb
+++ b/application/test/controllers/concerns/connector_resolver_test.rb
@@ -1,0 +1,45 @@
+require 'test_helper'
+
+class ConnectorResolverTest < ActionController::TestCase
+  class DummyController < ActionController::Base
+    include LoggingCommon
+    include ConnectorResolver
+
+    before_action :parse_connector_type
+    before_action :build_repo_url
+    before_action :validate_repo_url
+
+    def show
+      render plain: 'ok'
+    end
+  end
+
+  tests DummyController
+
+  def setup
+    @routes = ActionDispatch::Routing::RouteSet.new
+    @routes.draw do
+      get 'show' => 'connector_resolver_test/dummy#show'
+      root to: 'connector_resolver_test/dummy#show'
+    end
+    @request.env['action_dispatch.routes'] = @routes
+  end
+
+  def stub_resolver(type:, object_url: 'https://example.org/')
+    mock_service = mock('RepoResolverService')
+    mock_service.stubs(:resolve).returns(Repo::RepoResolverResponse.new(object_url, type))
+    Repo::RepoResolverService.stubs(:new).returns(mock_service)
+  end
+
+  test 'validate_repo_url redirects when repo type mismatches' do
+    stub_resolver(type: ConnectorType.get('dataverse'), object_url: 'https://example.org/')
+    get :show, params: { connector_type: 'zenodo', server_domain: 'example.org' }
+    assert_redirected_to '/'
+  end
+
+  test 'validate_repo_url allows matching repo type' do
+    stub_resolver(type: ConnectorType.get('zenodo'), object_url: 'https://example.org/')
+    get :show, params: { connector_type: 'zenodo', server_domain: 'example.org' }
+    assert_response :success
+  end
+end

--- a/application/test/controllers/explore_controller_test.rb
+++ b/application/test/controllers/explore_controller_test.rb
@@ -1,11 +1,6 @@
 require "test_helper"
 
 class ExploreControllerTest < ActionDispatch::IntegrationTest
-  def setup
-    @repo_db = Repo::RepoDb.new(db_path: Tempfile.new('repo').path)
-    RepoRegistry.repo_db = @repo_db
-  end
-
   def stub_handler(action, result: nil, exception: nil)
     handler = mock('ExploreHandler')
     handler.stubs(:params_schema).returns([])
@@ -15,23 +10,29 @@ class ExploreControllerTest < ActionDispatch::IntegrationTest
     ConnectorHandlerDispatcher.stubs(:handler).returns(handler)
   end
 
+  def stub_repo_resolver(type:, object_url: 'https://example.org/')
+    mock_service = mock('RepoResolverService')
+    mock_service.stubs(:resolve).returns(Repo::RepoResolverResponse.new(object_url, type))
+    Repo::RepoResolverService.stubs(:new).returns(mock_service)
+  end
+
   test 'redirects when repo url is invalid' do
     get '/explore/zenodo/%20/records/1'
 
     assert_redirected_to root_path
-    assert_equal I18n.t('explore.show.message_invalid_repo_url', repo_url: ''), flash[:alert]
+    assert_equal I18n.t('connector_resolver.message_invalid_repo_url', repo_url: ''), flash[:alert]
   end
 
   test 'redirects when connector type is invalid' do
     get '/explore/bogus/example.org/records/1'
 
     assert_redirected_to root_path
-    assert_equal I18n.t('explore.message_invalid_connector_type', connector_type: 'bogus'), flash[:alert]
+    assert_equal I18n.t('connector_resolver.message_invalid_connector_type', connector_type: 'bogus'), flash[:alert]
   end
 
   test 'show action renders template when handler succeeds' do
     stub_handler(:show, result: ConnectorResult.new(template: '/sitemap/index', locals: {}, success: true))
-    @repo_db.set('https://example.org', type: ConnectorType.get('zenodo'))
+    stub_repo_resolver(type: ConnectorType.get('zenodo'), object_url: 'https://example.org/')
 
     get explore_url(
       connector_type: 'zenodo',
@@ -45,7 +46,7 @@ class ExploreControllerTest < ActionDispatch::IntegrationTest
 
   test 'show action renders partial when handler succeeds via ajax request' do
     stub_handler(:show, result: ConnectorResult.new(template: '/sitemap/index', locals: {}, success: true))
-    @repo_db.set('https://example.org', type: ConnectorType.get('zenodo'))
+    stub_repo_resolver(type: ConnectorType.get('zenodo'), object_url: 'https://example.org/')
 
     get explore_url(
       connector_type: 'zenodo',
@@ -59,7 +60,7 @@ class ExploreControllerTest < ActionDispatch::IntegrationTest
 
   test 'show action redirects to provided redirect_url when handler specifies' do
     stub_handler(:show, result: ConnectorResult.new(redirect_url: '/next', message: { notice: 'ok' }, success: true))
-    @repo_db.set('https://example.org', type: ConnectorType.get('zenodo'))
+    stub_repo_resolver(type: ConnectorType.get('zenodo'), object_url: 'https://example.org/')
 
     get explore_url(
       connector_type: 'zenodo',
@@ -74,7 +75,7 @@ class ExploreControllerTest < ActionDispatch::IntegrationTest
 
   test 'show action redirects back when handler requests redirect_back' do
     stub_handler(:show, result: ConnectorResult.new(redirect_back: true, message: { notice: 'ok' }, success: true))
-    @repo_db.set('https://example.org', type: ConnectorType.get('zenodo'))
+    stub_repo_resolver(type: ConnectorType.get('zenodo'), object_url: 'https://example.org/')
 
     get explore_url(
       connector_type: 'zenodo',
@@ -89,7 +90,7 @@ class ExploreControllerTest < ActionDispatch::IntegrationTest
 
   test 'show action redirects with message when handler fails' do
     stub_handler(:show, result: ConnectorResult.new(message: { alert: 'error' }, success: false))
-    @repo_db.set('https://example.org', type: ConnectorType.get('zenodo'))
+    stub_repo_resolver(type: ConnectorType.get('zenodo'), object_url: 'https://example.org/')
 
     get explore_url(
       connector_type: 'zenodo',
@@ -104,7 +105,7 @@ class ExploreControllerTest < ActionDispatch::IntegrationTest
 
   test 'show action renders flash messages when handler fails via ajax request' do
     stub_handler(:show, result: ConnectorResult.new(message: { alert: 'error' }, success: false))
-    @repo_db.set('https://example.org', type: ConnectorType.get('zenodo'))
+    stub_repo_resolver(type: ConnectorType.get('zenodo'), object_url: 'https://example.org/')
 
     get explore_url(
       connector_type: 'zenodo',
@@ -119,7 +120,7 @@ class ExploreControllerTest < ActionDispatch::IntegrationTest
 
   test 'show action redirects with error message when handler raises' do
     stub_handler(:show, exception: StandardError.new('boom'))
-    @repo_db.set('https://example.org', type: ConnectorType.get('zenodo'))
+    stub_repo_resolver(type: ConnectorType.get('zenodo'), object_url: 'https://example.org/')
 
     get explore_url(
       connector_type: 'zenodo',
@@ -134,7 +135,7 @@ class ExploreControllerTest < ActionDispatch::IntegrationTest
 
   test 'create action redirects with message from handler' do
     stub_handler(:create, result: ConnectorResult.new(message: { notice: 'ok' }, success: true))
-    @repo_db.set('https://example.org', type: ConnectorType.get('zenodo'))
+    stub_repo_resolver(type: ConnectorType.get('zenodo'), object_url: 'https://example.org/')
 
     post explore_url(
       connector_type: 'zenodo',
@@ -149,7 +150,7 @@ class ExploreControllerTest < ActionDispatch::IntegrationTest
 
   test 'create action redirects with error message when handler raises' do
     stub_handler(:create, exception: StandardError.new('boom'))
-    @repo_db.set('https://example.org', type: ConnectorType.get('zenodo'))
+    stub_repo_resolver(type: ConnectorType.get('zenodo'), object_url: 'https://example.org/')
 
     post explore_url(
       connector_type: 'zenodo',
@@ -163,6 +164,7 @@ class ExploreControllerTest < ActionDispatch::IntegrationTest
   end
 
   test 'show action redirects when repo url not in repo db' do
+    stub_repo_resolver(type: ConnectorType.get('dataverse'), object_url: 'https://missing.org/')
     get explore_url(
       connector_type: 'zenodo',
       server_domain: 'missing.org',
@@ -171,10 +173,11 @@ class ExploreControllerTest < ActionDispatch::IntegrationTest
     )
 
     assert_redirected_to root_path
-    assert_equal I18n.t('explore.show.message_invalid_repo_url', repo_url: 'https://missing.org/'), flash[:alert]
+    assert_equal I18n.t('connector_resolver.message_invalid_repo_url', repo_url: 'https://missing.org/'), flash[:alert]
   end
 
   test 'create action redirects when repo url not in repo db' do
+    stub_repo_resolver(type: ConnectorType.get('dataverse'), object_url: 'https://missing.org/')
     post explore_url(
       connector_type: 'zenodo',
       server_domain: 'missing.org',
@@ -183,7 +186,7 @@ class ExploreControllerTest < ActionDispatch::IntegrationTest
     )
 
     assert_redirected_to root_path
-    assert_equal I18n.t('explore.create.message_invalid_repo_url', repo_url: 'https://missing.org/'), flash[:alert]
+    assert_equal I18n.t('connector_resolver.message_invalid_repo_url', repo_url: 'https://missing.org/'), flash[:alert]
   end
 end
 


### PR DESCRIPTION
## Description
In the explorer controller the repo validation was incorrect.
Add a new concern to validate the URL the user is exploring is for one of the repositories the application supports.

## Testing
- [ ] Added/updated tests
- [ ] All tests pass locally
- [ ] Tested manually (describe how)

## Documentation
- [ ] Updated relevant documentation
- [ ] No documentation changes needed