### PR TITLE
fix: Fixed download and upload files sorting in all views

### DIFF
--- a/application/app/models/project.rb
+++ b/application/app/models/project.rb
@@ -39,11 +39,11 @@ class Project < ApplicationDiskRecord
     @files ||=
       begin
         directory = File.join(self.class.download_files_directory(id))
-        Dir.glob(File.join(directory, '*.yml'))
-           .select { |f| File.file?(f) }
-           .sort_by { |f| -File.ctime(f).to_f }
-           .map { |f| DownloadFile.find(id, File.basename(f, ".yml")) }
-           .compact
+        files = Dir.glob(File.join(directory, '*.yml'))
+                   .select { |f| File.file?(f) }
+                   .map { |f| DownloadFile.find(id, File.basename(f, '.yml')) }
+                   .compact
+        Common::FileSorter.new.most_relevant(files)
       end
   end
   alias_method :status_files, :download_files

--- a/application/app/models/upload_bundle.rb
+++ b/application/app/models/upload_bundle.rb
@@ -50,12 +50,12 @@ class UploadBundle < ApplicationDiskRecord
   def files
     @upload_files ||=
       begin
-        directory = File.join(self.class.directory_by_ids(project_id, id), "files")
-        Dir.glob(File.join(directory, '*.yml'))
-           .select { |f| File.file?(f) }
-           .sort_by { |f| File.ctime(f) }
-           .map { |f| UploadFile.find(project_id, id, File.basename(f, ".yml")) }
-           .compact
+        directory = File.join(self.class.directory_by_ids(project_id, id), 'files')
+        files = Dir.glob(File.join(directory, '*.yml'))
+                   .select { |f| File.file?(f) }
+                   .map { |f| UploadFile.find(project_id, id, File.basename(f, '.yml')) }
+                   .compact
+        Common::FileSorter.new.most_relevant(files)
       end
   end
   alias_method :status_files, :files

--- a/application/app/services/common/file_sorter.rb
+++ b/application/app/services/common/file_sorter.rb
@@ -1,0 +1,30 @@
+# frozen_string_literal: true
+
+module Common
+  class FileSorter
+    include DateTimeCommon
+
+    def most_relevant(files)
+      files.sort_by do |file|
+        [ status_priority(file.status), -to_time(file.creation_date).to_i ]
+      end
+    end
+
+    private
+
+    def status_priority(status)
+      case
+      when status.downloading? || status.uploading?
+        0
+      when status.pending?
+        1
+      when status.cancelled?
+        2
+      when status.error?
+        3
+      else
+        4
+      end
+    end
+  end
+end

--- a/application/app/services/download/download_files_provider.rb
+++ b/application/app/services/download/download_files_provider.rb
@@ -6,30 +6,17 @@ module Download
 
     def recent_files
       retention_period = Configuration.download_files_retention_period
-      all.select{|data| data.file.end_date.blank? || elapsed(data.file.end_date) < retention_period }
-         .sort_by do |data|
-        group = if data.file.start_date && data.file.end_date.nil?
-                  0 # In Progress
-                elsif data.file.start_date.nil?
-                  1 # Pending
-                else
-                  2 # Completed / Other
-                end
-
-        start_time = to_time(data.file.start_date)
-        created_time = to_time(data.file.creation_date)
-        time_value = group == 0 ? start_time : (group == 1 ? created_time : start_time)
-        [group, -time_value.to_i]
-      end
-
+      list = all.select { |data| data.file.end_date.blank? || elapsed(data.file.end_date) < retention_period }
+      file_map = list.to_h { |data| [ data.file, data ] }
+      Common::FileSorter.new.most_relevant(file_map.keys).map { |file| file_map[file] }
     end
 
     def pending_files
-      Project.all.flat_map(&:download_files).select{|f| f.status.pending?}
+      Project.all.flat_map(&:download_files).select { |f| f.status.pending? }
     end
 
     def processing_files
-      Project.all.flat_map(&:download_files).select{|f| f.status.downloading?}
+      Project.all.flat_map(&:download_files).select { |f| f.status.downloading? }
     end
 
     def all
@@ -39,6 +26,5 @@ module Download
         end
       end
     end
-
   end
 end

--- a/application/test/models/project_test.rb
+++ b/application/test/models/project_test.rb
@@ -201,12 +201,13 @@ class ProjectTest < ActiveSupport::TestCase
       target = create_valid_project
       target.save
       file1 = create_download_file(target, id: 'saved_1')
+      file1.creation_date = (Time.now - 120).strftime('%Y-%m-%dT%H:%M:%S')
       assert file1.save
-      sleep(0.1)# SLEEP TO HAVE DIFFERENT CREATION DATE
       file2 = create_download_file(target, id: 'saved_2')
+      file2.creation_date = (Time.now - 60).strftime('%Y-%m-%dT%H:%M:%S')
       assert file2.save
-      sleep(0.1)# SLEEP TO HAVE DIFFERENT CREATION DATE
       file3 = create_download_file(target, id: 'saved_3')
+      file3.creation_date = Time.now.strftime('%Y-%m-%dT%H:%M:%S')
       assert file3.save
 
       saved_project = Project.find(target.id)

--- a/application/test/models/upload_bundle_test.rb
+++ b/application/test/models/upload_bundle_test.rb
@@ -14,7 +14,7 @@ class UploadBundleTest < ActiveSupport::TestCase
       'metadata' => {
         'persistent_id' => '',
         'dataverse_url' => '',
-        'api_key' => '',
+        'api_key' => ''
       }
     }
     @project = Project.new id: '456-789', name: 'Test Project'
@@ -139,17 +139,16 @@ class UploadBundleTest < ActiveSupport::TestCase
   test 'files returns upload files sorted' do
     f1 = create_upload_file(@project, @upload_bundle)
     f2 = create_upload_file(@project, @upload_bundle)
+    f1.creation_date = (Time.now - 60).strftime('%Y-%m-%dT%H:%M:%S')
+    f2.creation_date = Time.now.strftime('%Y-%m-%dT%H:%M:%S')
     UploadFile.stubs(:find).with(@project.id, @upload_bundle.id, f1.id).returns(f1)
     UploadFile.stubs(:find).with(@project.id, @upload_bundle.id, f2.id).returns(f2)
     dir = File.join(Project.upload_bundles_directory(@project.id), @upload_bundle.id, 'files')
     FileUtils.mkdir_p(dir)
-    file1 = File.join(dir, "#{f1.id}.yml")
-    file2 = File.join(dir, "#{f2.id}.yml")
-    FileUtils.touch(file1)
-    sleep 0.1
-    FileUtils.touch(file2)
+    FileUtils.touch(File.join(dir, "#{f1.id}.yml"))
+    FileUtils.touch(File.join(dir, "#{f2.id}.yml"))
     files = @upload_bundle.files
-    assert_equal [f1, f2], files
+    assert_equal [ f2, f1 ], files
   end
 
   def map_objects(hash)

--- a/application/test/services/common/file_sorter_test.rb
+++ b/application/test/services/common/file_sorter_test.rb
@@ -1,0 +1,73 @@
+# frozen_string_literal: true
+
+require 'test_helper'
+
+module Common
+  class FileSorterTest < ActiveSupport::TestCase
+    def setup
+      @sorter = FileSorter.new
+      @project = create_project
+      @upload_bundle = create_upload_bundle(@project)
+    end
+
+    test 'most_relevant sorts files by status and creation date' do
+      times = (1..10).map { |i| format('2023-01-%02dT00:00:00', i) }
+
+      in_progress_new = create_download_file(@project)
+      in_progress_new.status = FileStatus::DOWNLOADING
+      in_progress_new.creation_date = times[9]
+
+      in_progress_old = create_upload_file(@project, @upload_bundle)
+      in_progress_old.status = FileStatus::UPLOADING
+      in_progress_old.creation_date = times[8]
+
+      pending_new = create_upload_file(@project, @upload_bundle)
+      pending_new.status = FileStatus::PENDING
+      pending_new.creation_date = times[7]
+
+      pending_old = create_download_file(@project)
+      pending_old.status = FileStatus::PENDING
+      pending_old.creation_date = times[6]
+
+      cancelled_new = create_upload_file(@project, @upload_bundle)
+      cancelled_new.status = FileStatus::CANCELLED
+      cancelled_new.creation_date = times[5]
+
+      cancelled_old = create_download_file(@project)
+      cancelled_old.status = FileStatus::CANCELLED
+      cancelled_old.creation_date = times[4]
+
+      error_new = create_download_file(@project)
+      error_new.status = FileStatus::ERROR
+      error_new.creation_date = times[3]
+
+      error_old = create_upload_file(@project, @upload_bundle)
+      error_old.status = FileStatus::ERROR
+      error_old.creation_date = times[2]
+
+      success_new = create_upload_file(@project, @upload_bundle)
+      success_new.status = FileStatus::SUCCESS
+      success_new.creation_date = times[1]
+
+      success_old = create_download_file(@project)
+      success_old.status = FileStatus::SUCCESS
+      success_old.creation_date = times[0]
+
+      expected = [
+        in_progress_new,
+        in_progress_old,
+        pending_new,
+        pending_old,
+        cancelled_new,
+        cancelled_old,
+        error_new,
+        error_old,
+        success_new,
+        success_old
+      ]
+
+      shuffled = expected.shuffle(random: Random.new(1))
+      assert_equal expected, @sorter.most_relevant(shuffled)
+    end
+  end
+end

--- a/application/test/services/upload/upload_files_provider_test.rb
+++ b/application/test/services/upload/upload_files_provider_test.rb
@@ -8,27 +8,29 @@ class Upload::UploadFilesProviderTest < ActiveSupport::TestCase
   end
 
   test 'pending_files filters pending status' do
-    project = upload_project(files:1)
-    Project.stubs(:all).returns([project])
+    project = upload_project(files: 1)
+    Project.stubs(:all).returns([ project ])
     files = @provider.pending_files
     assert_equal 1, files.length
   end
 
   test 'processing_files filters uploading status' do
-    project = upload_project(files:1)
+    project = upload_project(files: 1)
     project.upload_bundles.first.files.first.status = FileStatus::UPLOADING
-    Project.stubs(:all).returns([project])
+    Project.stubs(:all).returns([ project ])
     files = @provider.processing_files
     assert_equal 1, files.length
   end
 
   test 'recent_files sorts by state and time' do
-    project = upload_project(files:2)
+    project = upload_project(files: 2)
     files = project.upload_bundles.first.files
-    files.first.start_date = Time.now
-    files.last.start_date = Time.now - 60
-    Project.stubs(:all).returns([project])
+    files.first.status = FileStatus::UPLOADING
+    files.first.creation_date = Time.now.strftime('%Y-%m-%dT%H:%M:%S')
+    files.last.status = FileStatus::UPLOADING
+    files.last.creation_date = (Time.now - 60).strftime('%Y-%m-%dT%H:%M:%S')
+    Project.stubs(:all).returns([ project ])
     list = @provider.recent_files
-    assert_equal [files.first, files.last], list.map(&:file)
+    assert_equal [ files.first, files.last ], list.map(&:file)
   end
 end

--- a/application/test/utils/model_helper.rb
+++ b/application/test/utils/model_helper.rb
@@ -1,5 +1,4 @@
 module ModelHelper
-
   def create_project
     Project.new(id: random_id, name: 'test_project')
   end
@@ -18,16 +17,17 @@ module ModelHelper
       file.filename = "#{random_id}.txt"
       file.status = FileStatus::PENDING
       file.size = 200
-      file.metadata = {test: 'test'}
+      file.creation_date = file_now
+      file.metadata = { test: 'test' }
     end
   end
 
   def upload_project(type: ConnectorType::DATAVERSE, files:)
     create_project.tap do |project|
-      upload_bundle = create_upload_bundle(project, type: type)
-      upload_files = Array.new(files) { create_upload_file(project, upload_bundle) }
-      upload_bundle.stubs(:files).returns(upload_files)
-      project.stubs(:upload_bundles).returns([upload_bundle])
+        upload_bundle = create_upload_bundle(project, type: type)
+        upload_files = Array.new(files) { create_upload_file(project, upload_bundle) }
+        upload_bundle.stubs(:files).returns(upload_files)
+        project.stubs(:upload_bundles).returns([ upload_bundle ])
     end
   end
 
@@ -37,7 +37,7 @@ module ModelHelper
       upload_bundle.id = id
       upload_bundle.name = "sample name"
       upload_bundle.type = type
-      upload_bundle.metadata = {test: 'test'}
+        upload_bundle.metadata = { test: 'test' }
       upload_bundle.stubs(:files).returns(files)
     end
   end
@@ -50,6 +50,7 @@ module ModelHelper
       file.filename = "#{random_id}.txt"
       file.status = FileStatus::PENDING
       file.size = 200
+      file.creation_date = file_now
       file.stubs(:upload_bundle).returns(upload_bundle)
     end
   end


### PR DESCRIPTION
## Description

Created File sorting module and applied the same sorting to all file lists. This creates a consistent view of the files across all pages.

## Related Issue
Fixes #322

## Changes Made
- Created a File Sorting module

## Testing
- [x] Added/updated tests
- [x] All tests pass locally
- [ ] Tested manually (describe how)

## Documentation
- [ ] Updated relevant documentation
- [x] No documentation changes needed