### PR TITLE
feat: Added repo url history to projects

### DIFF
--- a/application/app/connectors/dataverse/handlers/datasets.rb
+++ b/application/app/connectors/dataverse/handlers/datasets.rb
@@ -123,6 +123,10 @@ module Dataverse::Handlers
         return ConnectorResult.new(message: { alert: I18n.t('connectors.dataverse.datasets.download.error_generating_the_download_file') }, success: false)
       end
 
+      dataset_url = Dataverse::Concerns::DataverseUrlBuilder.build_dataset_url(repo_url.to_s, @persistent_id, version: version)
+      project.add_repo(dataset_url)
+      project.save
+
       ConnectorResult.new(message: { notice: I18n.t('connectors.dataverse.datasets.download.files_added_to_project', project_name: project.name) }, success: true)
     end
   end

--- a/application/app/connectors/zenodo/handlers/records.rb
+++ b/application/app/connectors/zenodo/handlers/records.rb
@@ -71,6 +71,9 @@ module Zenodo::Handlers
         return ConnectorResult.new(message: { alert: I18n.t('zenodo.records.message_save_file_error', project_name: project.name) }, success: false)
       end
       log_info('Download files created', { project_id: project.id, files: download_files.size })
+      record_url = Zenodo::Concerns::ZenodoUrlBuilder.build_record_url(repo_url.server_url, @record_id)
+      project.add_repo(record_url)
+      project.save
       ConnectorResult.new(message: { notice: I18n.t('zenodo.records.message_success', files: save_results.size, project_name: project.name) }, success: true)
     end
   end

--- a/application/app/services/zenodo/concerns/zenodo_url_builder.rb
+++ b/application/app/services/zenodo/concerns/zenodo_url_builder.rb
@@ -4,39 +4,56 @@ module Zenodo::Concerns::ZenodoUrlBuilder
   extend ActiveSupport::Concern
 
   def record_url
+    Zenodo::Concerns::ZenodoUrlBuilder.build_record_url(zenodo_url, record_id)
+  end
+
+  def build_record_url(zenodo_url, record_id)
+    raise 'zenodo_url is missing' unless zenodo_url
     raise 'record_id is missing' unless record_id
 
     FluentUrl.new(zenodo_url)
-      .add_path('records')
-      .add_path(record_id.to_s)
-      .to_s
+             .add_path('records')
+             .add_path(record_id.to_s)
+             .to_s
   end
 
   def file_url
+    Zenodo::Concerns::ZenodoUrlBuilder.build_file_url(zenodo_url, record_id, file_name)
+  end
+
+  def build_file_url(zenodo_url, record_id, file_name)
+    raise 'zenodo_url is missing' unless zenodo_url
     raise 'record_id is missing' unless record_id
     raise 'file_name is missing' unless file_name
 
     FluentUrl.new(zenodo_url)
-      .add_path('records')
-      .add_path(record_id.to_s)
-      .add_path('files')
-      .add_path(file_name)
-      .to_s
+             .add_path('records')
+             .add_path(record_id.to_s)
+             .add_path('files')
+             .add_path(file_name)
+             .to_s
   end
 
   def deposition_url
+    Zenodo::Concerns::ZenodoUrlBuilder.build_deposition_url(zenodo_url, deposition_id)
+  end
+
+  def build_deposition_url(zenodo_url, deposition_id)
+    raise 'zenodo_url is missing' unless zenodo_url
     raise 'deposition_id is missing' unless deposition_id
 
     FluentUrl.new(zenodo_url)
-      .add_path('uploads')
-      .add_path(deposition_id.to_s)
-      .to_s
+             .add_path('uploads')
+             .add_path(deposition_id.to_s)
+             .to_s
   end
 
   def user_depositions_url
     FluentUrl.new(zenodo_url)
-      .add_path('me')
-      .add_path('uploads')
-      .to_s
+             .add_path('me')
+             .add_path('uploads')
+             .to_s
   end
+
+  module_function :build_record_url, :build_file_url, :build_deposition_url
 end

--- a/application/test/connectors/dataverse/handlers/datasets_test.rb
+++ b/application/test/connectors/dataverse/handlers/datasets_test.rb
@@ -56,7 +56,7 @@ class Dataverse::Handlers::DatasetsTest < ActiveSupport::TestCase
   end
 
   test 'create initializes project and files' do
-    dataset = OpenStruct.new(version: '1', data: OpenStruct.new(dataset_persistent_id: 'pid', parents: []))
+    dataset = OpenStruct.new(version: '1', data: OpenStruct.new(dataset_persistent_id: 'different', parents: []))
     files_page = OpenStruct.new(total_count: 0, page: 1, query: nil, files: [])
     service = mock('service')
     service.expects(:find_dataset_version_by_persistent_id).with('pid', version: nil).returns(dataset)
@@ -65,7 +65,9 @@ class Dataverse::Handlers::DatasetsTest < ActiveSupport::TestCase
 
     Project.stubs(:find).with('1').returns(nil)
     project = mock('project')
-    project.stubs(:save).returns(true)
+    project.expects(:save).twice.returns(true)
+    dataset_url = Dataverse::Concerns::DataverseUrlBuilder.build_dataset_url(@repo_url.to_s, 'pid', version: '1')
+    project.expects(:add_repo).with(dataset_url)
     project.stubs(:name).returns('Proj')
     project.stubs(:id).returns('1')
 

--- a/application/test/connectors/zenodo/handlers/records_test.rb
+++ b/application/test/connectors/zenodo/handlers/records_test.rb
@@ -36,7 +36,9 @@ class Zenodo::Handlers::RecordsTest < ActiveSupport::TestCase
 
     Project.stubs(:find).with('1').returns(nil)
     project = mock('project')
-    project.stubs(:save).returns(true)
+    project.expects(:save).twice.returns(true)
+    record_url = Zenodo::Concerns::ZenodoUrlBuilder.build_record_url(@repo_url.server_url, '123')
+    project.expects(:add_repo).with(record_url)
     project.stubs(:name).returns('Proj')
     project.stubs(:id).returns(1)
 

--- a/application/test/models/project_test.rb
+++ b/application/test/models/project_test.rb
@@ -8,6 +8,12 @@ class ProjectTest < ActiveSupport::TestCase
     assert_equal 'test_project', target.name
     assert_equal '/tmp/test_project', target.download_dir
     assert_not_nil target.creation_date
+    assert_equal [], target.repo_urls
+  end
+
+  test "initializer stores empty repo_urls when nil provided" do
+    target = create_valid_project(repo_urls: nil)
+    assert_equal [], target.repo_urls
   end
 
   test "should be valid when all fields are populated" do
@@ -109,6 +115,7 @@ class ProjectTest < ActiveSupport::TestCase
       assert_equal 'ab12345', saved_project.id
       assert_equal 'test_project', saved_project.name
       assert_equal '/tmp/test_project', saved_project.download_dir
+      assert_equal [], saved_project.repo_urls
     end
   end
 
@@ -128,6 +135,7 @@ class ProjectTest < ActiveSupport::TestCase
       assert_equal target2.id, saved_project.id
       assert_equal target2.name, saved_project.name
       assert_equal target2.download_dir, saved_project.download_dir
+      assert_equal [], saved_project.repo_urls
     end
   end
 
@@ -147,6 +155,7 @@ class ProjectTest < ActiveSupport::TestCase
       assert_equal 'ab12345', saved_project.id
       assert_equal 'test_project', saved_project.name
       assert_equal '/tmp/test_project', saved_project.download_dir
+      assert_equal [], saved_project.repo_urls
     end
   end
 
@@ -263,14 +272,46 @@ class ProjectTest < ActiveSupport::TestCase
     end
   end
 
+  test "repo_urls default to empty and add_repo handles MRU" do
+    target = create_valid_project
+    assert_equal [], target.repo_urls
+
+    target.add_repo('http://example.com/one')
+    target.add_repo('http://example.com/two')
+    target.add_repo('http://example.com/one')
+
+    assert_equal ['http://example.com/one', 'http://example.com/two'], target.repo_urls
+  end
+
+  test "add_repo enforces max of 20 repo_urls" do
+    target = create_valid_project
+    urls = (1..21).map { |i| "http://example.com/repo#{i}" }
+    urls.each { |u| target.add_repo(u) }
+
+    assert_equal 20, target.repo_urls.size
+    assert_equal urls.last(20).reverse, target.repo_urls
+  end
+
+  test "repo_urls persist when saved" do
+    in_temp_directory do
+      target = create_valid_project
+      target.add_repo('http://example.com/a')
+      target.add_repo('http://example.com/b')
+      assert target.save
+
+      saved = Project.find(target.id)
+      assert_equal ['http://example.com/b', 'http://example.com/a'], saved.repo_urls
+    end
+  end
+
   private
 
-  def create_valid_project(id: 'ab12345', name: 'test_project', download_dir: '/tmp/test_project')
-    Project.new(id: id, name: name, download_dir: download_dir)
+  def create_valid_project(id: 'ab12345', name: 'test_project', download_dir: '/tmp/test_project', repo_urls: [])
+    Project.new(id: id, name: name, download_dir: download_dir, repo_urls: repo_urls)
   end
 
   def project_hash(project)
-    {id: project.id, name: project.name, download_dir: project.download_dir, creation_date: project.creation_date}.stringify_keys
+    {id: project.id, name: project.name, download_dir: project.download_dir, creation_date: project.creation_date, repo_urls: project.repo_urls}.stringify_keys
   end
 
   def in_temp_directory

--- a/application/test/services/zenodo/concerns/zenodo_url_builder_test.rb
+++ b/application/test/services/zenodo/concerns/zenodo_url_builder_test.rb
@@ -27,6 +27,21 @@ class Zenodo::Concerns::ZenodoUrlBuilderTest < ActiveSupport::TestCase
     assert_equal 'https://zenodo.org/uploads/20', @builder.deposition_url
   end
 
+  test 'build_record_url builds correct URL' do
+    url = Zenodo::Concerns::ZenodoUrlBuilder.build_record_url('https://zenodo.org', '1')
+    assert_equal 'https://zenodo.org/records/1', url
+  end
+
+  test 'build_file_url builds correct URL' do
+    url = Zenodo::Concerns::ZenodoUrlBuilder.build_file_url('https://zenodo.org', '1', 'file.txt')
+    assert_equal 'https://zenodo.org/records/1/files/file.txt', url
+  end
+
+  test 'build_deposition_url builds correct URL' do
+    url = Zenodo::Concerns::ZenodoUrlBuilder.build_deposition_url('https://zenodo.org', '20')
+    assert_equal 'https://zenodo.org/uploads/20', url
+  end
+
   test 'user_depositions_url builds correct URL' do
     assert_equal 'https://zenodo.org/me/uploads', @builder.user_depositions_url
   end


### PR DESCRIPTION
## Description
Added repo url history to projects to store the URLs of the datasets used to download files.
These URLs will be used to improve the UI when selecting more files to download.

## Related Issue
relates to #405 

## Testing
- [x] Added/updated tests
- [x] All tests pass locally
- [ ] Tested manually (describe how)

## Documentation
- [ ] Updated relevant documentation
- [x] No documentation changes needed