### PR TITLE
feat: Pre-select project when clicking through to a explore page from project details.

### DIFF
--- a/application/app/connectors/dataverse/download_connector_metadata.rb
+++ b/application/app/connectors/dataverse/download_connector_metadata.rb
@@ -26,7 +26,7 @@ module Dataverse
         object_type: 'datasets',
         object_id: dataset_id,
         version: version,
-        selected_project: project_id
+        from_project: project_id
       )
     end
 

--- a/application/app/connectors/dataverse/download_connector_metadata.rb
+++ b/application/app/connectors/dataverse/download_connector_metadata.rb
@@ -26,7 +26,7 @@ module Dataverse
         object_type: 'datasets',
         object_id: dataset_id,
         version: version,
-        from_project: project_id
+        from_project: @project_id
       )
     end
 
@@ -36,6 +36,6 @@ module Dataverse
 
     private
 
-    attr_reader :metadata, :project_id
+    attr_reader :metadata
   end
 end

--- a/application/app/connectors/dataverse/download_connector_metadata.rb
+++ b/application/app/connectors/dataverse/download_connector_metadata.rb
@@ -7,6 +7,7 @@ module Dataverse
     def initialize(download_file)
       @metadata = ActiveSupport::OrderedOptions.new
       @metadata.merge!(download_file.metadata.to_h.deep_symbolize_keys)
+      @project_id = download_file.project_id
     end
 
     def repo_name
@@ -24,7 +25,8 @@ module Dataverse
         server_port: dataverse_uri.port,
         object_type: 'datasets',
         object_id: dataset_id,
-        version: version
+        version: version,
+        selected_project: project_id
       )
     end
 
@@ -34,6 +36,6 @@ module Dataverse
 
     private
 
-    attr_reader :metadata
+    attr_reader :metadata, :project_id
   end
 end

--- a/application/app/connectors/dataverse/handlers/datasets.rb
+++ b/application/app/connectors/dataverse/handlers/datasets.rb
@@ -122,11 +122,6 @@ module Dataverse::Handlers
       if save_results.include?(false)
         return ConnectorResult.new(message: { alert: I18n.t('connectors.dataverse.datasets.download.error_generating_the_download_file') }, success: false)
       end
-
-      dataset_url = Dataverse::Concerns::DataverseUrlBuilder.build_dataset_url(repo_url.to_s, @persistent_id, version: version)
-      project.add_repo(dataset_url)
-      project.save
-
       ConnectorResult.new(message: { notice: I18n.t('connectors.dataverse.datasets.download.files_added_to_project', project_name: project.name) }, success: true)
     end
   end

--- a/application/app/connectors/zenodo/download_connector_metadata.rb
+++ b/application/app/connectors/zenodo/download_connector_metadata.rb
@@ -23,7 +23,7 @@ module Zenodo
         object_id: type_id,
         server_scheme: repo_url.scheme_override,
         server_port: repo_url.port_override,
-        from_project: project_id
+        from_project: @project_id
       )
     end
 
@@ -33,6 +33,6 @@ module Zenodo
 
     private
 
-    attr_reader :metadata, :project_id
+    attr_reader :metadata
   end
 end

--- a/application/app/connectors/zenodo/download_connector_metadata.rb
+++ b/application/app/connectors/zenodo/download_connector_metadata.rb
@@ -23,7 +23,7 @@ module Zenodo
         object_id: type_id,
         server_scheme: repo_url.scheme_override,
         server_port: repo_url.port_override,
-        selected_project: project_id
+        from_project: project_id
       )
     end
 

--- a/application/app/connectors/zenodo/download_connector_metadata.rb
+++ b/application/app/connectors/zenodo/download_connector_metadata.rb
@@ -7,6 +7,7 @@ module Zenodo
     def initialize(download_file)
       @metadata = ActiveSupport::OrderedOptions.new
       @metadata.merge!(download_file.metadata.to_h.deep_symbolize_keys)
+      @project_id = download_file.project_id
     end
 
     def repo_name
@@ -21,7 +22,8 @@ module Zenodo
         object_type: type,
         object_id: type_id,
         server_scheme: repo_url.scheme_override,
-        server_port: repo_url.port_override
+        server_port: repo_url.port_override,
+        selected_project: project_id
       )
     end
 
@@ -31,6 +33,6 @@ module Zenodo
 
     private
 
-    attr_reader :metadata
+    attr_reader :metadata, :project_id
   end
 end

--- a/application/app/connectors/zenodo/handlers/records.rb
+++ b/application/app/connectors/zenodo/handlers/records.rb
@@ -71,9 +71,6 @@ module Zenodo::Handlers
         return ConnectorResult.new(message: { alert: I18n.t('zenodo.records.message_save_file_error', project_name: project.name) }, success: false)
       end
       log_info('Download files created', { project_id: project.id, files: download_files.size })
-      record_url = Zenodo::Concerns::ZenodoUrlBuilder.build_record_url(repo_url.server_url, @record_id)
-      project.add_repo(record_url)
-      project.save
       ConnectorResult.new(message: { notice: I18n.t('zenodo.records.message_success', files: save_results.size, project_name: project.name) }, success: true)
     end
   end

--- a/application/app/controllers/application_controller.rb
+++ b/application/app/controllers/application_controller.rb
@@ -4,6 +4,8 @@ class ApplicationController < ActionController::Base
   # Only allow modern browsers supporting webp images, web push, badges, import maps, CSS nesting, and CSS :has.
   allow_browser versions: :modern
   before_action :load_user_settings
+  before_action :set_redirect_params
+  after_action :stash_redirect_params
 
   def ajax_request?
     request.xhr? || request.headers['X-Requested-With'] == 'XMLHttpRequest'
@@ -14,5 +16,21 @@ class ApplicationController < ActionController::Base
   def load_user_settings
     Current.settings = UserSettings.new
     @active_project = Project.find(Current.settings.user_settings.active_project.to_s)
+  end
+
+  def set_redirect_params
+    Current::PERSISTED_ATTRIBUTES.each do |key|
+      value = request.request_parameters[key] || params[key] || flash[:redirect_params]&.[](key.to_s)
+      next if value.nil?
+
+      Current.public_send("#{key}=", value)
+    end
+  end
+
+  def stash_redirect_params
+    return unless response.redirect?
+
+    redirect_params = params.permit(*Current::PERSISTED_ATTRIBUTES)
+    flash[:redirect_params] = redirect_params.to_h if redirect_params.present?
   end
 end

--- a/application/app/helpers/application_helper.rb
+++ b/application/app/helpers/application_helper.rb
@@ -52,7 +52,7 @@ module ApplicationHelper
   end
 
   def flash_messages(messages = flash)
-    messages.to_hash.slice(*ALERT_TYPES.keys)
+    messages.to_hash.symbolize_keys.slice(*ALERT_TYPES.keys)
   end
 
   def status_badge(status, title: nil, filename: nil)

--- a/application/app/helpers/application_helper.rb
+++ b/application/app/helpers/application_helper.rb
@@ -1,6 +1,14 @@
 module ApplicationHelper
   include DateTimeCommon
 
+  ALERT_TYPES = {
+    error: 'danger',
+    alert: 'danger',
+    warning: 'warning',
+    notice: 'success',
+    info: 'success'
+  }.freeze
+
   def restart_url
     "/nginx/stop?redir=#{root_path}"
   end
@@ -39,8 +47,12 @@ module ApplicationHelper
   end
 
   def alert_class(type)
-    class_type = {error: 'danger', alert: 'danger', warning: 'warning', notice: 'success', info: 'success'}.fetch(type.to_sym, 'info')
+    class_type = ALERT_TYPES.fetch(type.to_sym, 'info')
     "alert alert-#{class_type}"
+  end
+
+  def flash_messages(messages = flash)
+    messages.to_hash.slice(*ALERT_TYPES.keys)
   end
 
   def status_badge(status, title: nil, filename: nil)

--- a/application/app/helpers/projects_helper.rb
+++ b/application/app/helpers/projects_helper.rb
@@ -4,29 +4,32 @@ module ProjectsHelper
     Current.settings.user_settings.active_project.to_s == project_id
   end
 
+  def select_project_list_name(project)
+    return project.name unless active_project?(project.id.to_s)
+    "#{project.name} (#{t('helpers.projects.active_project_text')})"
+  end
+
+  # frozen_string_literal: true
+
   def select_project_list
-    current = nil
-    active = nil
-    others = []
+    current_id = Current.from_project.to_s
+    active_id =  Current.settings.user_settings.active_project.to_s
+    current = []
+    active  = []
+    others  = []
 
     Project.all.each do |project|
-      is_active = active_project?(project.id.to_s)
-      is_current = Current.from_project.present? && project.id.to_s == Current.from_project.to_s
-
-      if is_active
-        project.name = "#{project.name} (#{t('helpers.projects.active_project_text')})"
-        active = project
+      pid = project.id.to_s
+      if pid == current_id
+        current << project
+      elsif pid == active_id
+        active << project
+      else
+        others << project
       end
-      current = project if is_current
-
-      others << project unless is_active || is_current
     end
 
-    [].tap do |list|
-      list << current if current
-      list << active if active && active != current
-      list.concat(others)
-    end
+    current + active + others
   end
 
   def project_header_class(active)

--- a/application/app/helpers/projects_helper.rb
+++ b/application/app/helpers/projects_helper.rb
@@ -32,6 +32,12 @@ module ProjectsHelper
     current + active + others
   end
 
+  def most_recent_explore_url(project)
+    files = project.download_files
+    most_recent = Common::FileSorter.new.most_recent(files).first
+    most_recent.connector_metadata.files_url if most_recent
+  end
+
   def project_header_class(active)
     active ? 'bg-primary-subtle' : 'bg-body-secondary'
   end

--- a/application/app/helpers/projects_helper.rb
+++ b/application/app/helpers/projects_helper.rb
@@ -5,15 +5,27 @@ module ProjectsHelper
   end
 
   def select_project_list
-    [].tap do |list|
-      Project.all.each do |project|
-        if active_project?(project.id.to_s)
-          project.name = "#{project.name} (#{t('helpers.projects.active_project_text')})"
-          list.unshift(project)
-        else
-          list << project
-        end
+    current = nil
+    active = nil
+    others = []
+
+    Project.all.each do |project|
+      is_active = active_project?(project.id.to_s)
+      is_current = Current.selected_project.present? && project.id.to_s == Current.selected_project.to_s
+
+      if is_active
+        project.name = "#{project.name} (#{t('helpers.projects.active_project_text')})"
+        active = project
       end
+      current = project if is_current
+
+      others << project unless is_active || is_current
+    end
+
+    [].tap do |list|
+      list << current if current
+      list << active if active && active != current
+      list.concat(others)
     end
   end
 

--- a/application/app/helpers/projects_helper.rb
+++ b/application/app/helpers/projects_helper.rb
@@ -11,7 +11,7 @@ module ProjectsHelper
 
     Project.all.each do |project|
       is_active = active_project?(project.id.to_s)
-      is_current = Current.selected_project.present? && project.id.to_s == Current.selected_project.to_s
+      is_current = Current.from_project.present? && project.id.to_s == Current.from_project.to_s
 
       if is_active
         project.name = "#{project.name} (#{t('helpers.projects.active_project_text')})"

--- a/application/app/models/current.rb
+++ b/application/app/models/current.rb
@@ -1,4 +1,4 @@
 class Current < ActiveSupport::CurrentAttributes
-  attribute :settings
-
+  PERSISTED_ATTRIBUTES = %i[selected_project].freeze
+  attribute :settings, *PERSISTED_ATTRIBUTES
 end

--- a/application/app/models/current.rb
+++ b/application/app/models/current.rb
@@ -1,4 +1,4 @@
 class Current < ActiveSupport::CurrentAttributes
-  PERSISTED_ATTRIBUTES = %i[selected_project].freeze
+  PERSISTED_ATTRIBUTES = %i[from_project].freeze
   attribute :settings, *PERSISTED_ATTRIBUTES
 end

--- a/application/app/models/project.rb
+++ b/application/app/models/project.rb
@@ -5,10 +5,8 @@ class Project < ApplicationDiskRecord
   include FileStatusSummary
   include LoggingCommon
 
-  MAX_REPO_URLS = 20
-
   REQUIRED_ATTRIBUTES = %w[id name download_dir creation_date].freeze
-  ATTRIBUTES = (REQUIRED_ATTRIBUTES + %w[repo_urls]).freeze
+  ATTRIBUTES = REQUIRED_ATTRIBUTES
 
   attr_accessor(*ATTRIBUTES)
 
@@ -31,24 +29,11 @@ class Project < ApplicationDiskRecord
     load_from_file(filename)
   end
 
-  def initialize(id: nil, name: nil, download_dir: nil, repo_urls: nil)
+  def initialize(id: nil, name: nil, download_dir: nil)
     self.id = id || Project.generate_id
     self.name = name || self.id
     self.download_dir = download_dir || File.join(Configuration.download_root, self.id.to_s)
     self.creation_date = DateTimeCommon.now
-    self.repo_urls = repo_urls || []
-  end
-
-  def repo_urls=(urls)
-    @repo_urls = Array(urls)
-  end
-
-  def add_repo(url)
-    return if url.blank?
-
-    repo_urls.delete(url)
-    repo_urls.unshift(url)
-    self.repo_urls = repo_urls.take(MAX_REPO_URLS)
   end
 
   def download_files

--- a/application/app/services/common/file_sorter.rb
+++ b/application/app/services/common/file_sorter.rb
@@ -10,6 +10,12 @@ module Common
       end
     end
 
+    def most_recent(files)
+      files.sort_by do |file|
+        -sort_date(file)
+      end
+    end
+
     private
 
     def sort_date(file)

--- a/application/app/services/repo/repo_resolver_context.rb
+++ b/application/app/services/repo/repo_resolver_context.rb
@@ -21,21 +21,4 @@ module Repo
       RepoResolverResponse.new(object_url, type)
     end
   end
-
-  class RepoResolverResponse
-    attr_reader :object_url, :type
-    def initialize(object_url, type)
-      @object_url = object_url
-      @type = type
-    end
-
-    def resolved?
-      object_url.present? && type.present?
-    end
-
-    def unknown?
-      type.nil?
-    end
-  end
 end
-

--- a/application/app/services/repo/repo_resolver_response.rb
+++ b/application/app/services/repo/repo_resolver_response.rb
@@ -1,0 +1,19 @@
+# frozen_string_literal: true
+
+module Repo
+  class RepoResolverResponse
+    attr_reader :object_url, :type
+    def initialize(object_url, type)
+      @object_url = object_url
+      @type = type
+    end
+
+    def resolved?
+      object_url.present? && type.present?
+    end
+
+    def unknown?
+      type.nil?
+    end
+  end
+end

--- a/application/app/views/layouts/_flash_messages.html.erb
+++ b/application/app/views/layouts/_flash_messages.html.erb
@@ -1,5 +1,5 @@
 <div id="flash-container" class="position-relative z-3">
-  <% flash.each do |type, message| %>
+  <% flash_messages.each do |type, message| %>
     <div class="alert-dismissible fade show <%= alert_class(type) %>" role="alert">
       <%= message.html_safe %>
       <button type="button" class="btn-close" data-bs-dismiss="alert" aria-label="<%= t('.button_close_label') %>"></button>

--- a/application/app/views/layouts/_project_bar.html.erb
+++ b/application/app/views/layouts/_project_bar.html.erb
@@ -20,13 +20,9 @@
   </div>
 
   <div>
-    <a href="<%= files_app_url(Project.project_metadata_dir(project.id)) %>"
-       target="_blank"
-       class="btn btn-sm btn-outline-primary ms-3"
-       title="<%= t('.link_open_metadata_title') %>">
-      <i class="bi bi-card-list" aria-hidden="true"></i>
-      <span class="visually-hidden"><%= t('.link_open_metadata_title') %></span>
-    </a>
+    <%= render partial: '/shared/metadata_folder_link',
+               locals: { path: Project.project_metadata_dir(project.id),
+                         class: 'btn btn-sm btn-outline-primary ms-3' } %>
     <button class="btn btn-sm btn-outline-primary cursor-default" title="<%= t('.button_active_project_title') %>">
       <i class="bi bi-check-circle-fill" aria-hidden="true"></i>
       <span class="visually-hidden"><%= t('.button_active_project_title') %></span>

--- a/application/app/views/layouts/_repo_resolver_bar.html.erb
+++ b/application/app/views/layouts/_repo_resolver_bar.html.erb
@@ -4,6 +4,7 @@
   color = local_assigns.fetch(:color, 'bg-primary-subtle')
   collapse = local_assigns.fetch(:collapse, false)
   show_images = local_assigns.fetch(:show_images, true)
+  url = local_assigns.fetch(:url, repo_resolver_path)
 %>
 <div id="<%= id %>" class="shadow-sm <%= color %> <%= 'collapse' if collapse %>" style="transition: none;"
      data-controller="focus-on-event"
@@ -24,7 +25,7 @@
 
     <!-- Resolver Form (right aligned) -->
     <%= render layout: "shared/button_to", locals: {
-      url: repo_resolver_path,
+      url: url,
       form_class: 'flex-grow-1 d-flex align-items-center gap-2',
       class: 'btn-primary-dark',
       icon_html: image_tag('icon.png', alt: t('.button_submit_icon_alt'), class: 'icon-class d-block', style: 'height: 1rem; width: auto; object-fit: contain;' ),

--- a/application/app/views/projects/index/_project_summary.html.erb
+++ b/application/app/views/projects/index/_project_summary.html.erb
@@ -13,13 +13,8 @@
     <strong><%= t('.button_toggle_label') %></strong>
   </a>
   <div>
-    <a href="<%= files_app_url(Project.project_metadata_dir(project.id)) %>"
-       target="_blank"
-       class="btn btn-sm btn-outline-secondary"
-       title="<%= t('.button_metadata_folder_title') %>">
-      <i class="bi bi-card-list" aria-hidden="true"></i>
-      <span class="visually-hidden"><%= t('.button_metadata_folder_title') %></span>
-    </a>
+    <%= render partial: '/shared/metadata_folder_link',
+               locals: { path: Project.project_metadata_dir(project.id) } %>
   </div>
 </div>
 

--- a/application/app/views/projects/show/_download_actions.html.erb
+++ b/application/app/views/projects/show/_download_actions.html.erb
@@ -68,7 +68,7 @@
                 data-action="click->utils--icon-toggle#toggle"
                 data-bs-toggle="collapse"
                 data-bs-target="#download-repo-resolver"
-                title="Add new Datasource"
+                title="<%= t('.button_browse_dataset_title') %>"
                 aria-label="<%= t('.button_browse_dataset_title') %>"
                 role="button"
                 aria-expanded="false"

--- a/application/app/views/projects/show/_download_actions.html.erb
+++ b/application/app/views/projects/show/_download_actions.html.erb
@@ -43,21 +43,36 @@
         <%= render partial: '/shared/file_summary_widget', locals: project_progress_data(project.status_summary) %>
       </div>
 
-      <button data-controller="utils--icon-toggle"
-              data-utils--icon-toggle-icon-on-value="bi-plus-square-fill"
-              data-utils--icon-toggle-icon-off-value="bi-dash-square-fill"
-              data-action="click->utils--icon-toggle#toggle"
-              data-bs-toggle="collapse"
-              data-bs-target="#download-repo-resolver"
-              title="<%= t('.button_add_files_title') %>"
-              aria-label="<%= t('.button_add_files_text') %>"
-              role="button"
-              aria-expanded="false"
-              aria-controls="download-repo-resolver"
-              class="btn btn-outline-secondary btn-sm">
-        <i data-utils--icon-toggle-target="icon" class="bi bi-plus-square-fill" aria-hidden="true"></i>
-        <span class="ps-1"><%= t('.button_add_files_text') %></span>
-      </button>
+      <div>
+
+        <% explore_url = most_recent_explore_url(project) %>
+        <a href="<%= explore_url if explore_url %>"
+           class="btn btn-sm btn-outline-secondary <%= 'disabled' unless explore_url %>"
+           aria-label="<%= t('.button_add_files_title') %>"
+           title="<%= t('.button_add_files_title') %>"
+           aria-disabled="<%= explore_url.nil? %>">
+          <i class="bi bi-files" aria-hidden="true"></i>
+          <span><%= t('.button_add_files_text') %></span>
+        </a>
+
+        <button data-controller="utils--icon-toggle"
+                data-utils--icon-toggle-icon-on-value="bi-plus-square-fill"
+                data-utils--icon-toggle-icon-off-value="bi-dash-square-fill"
+                data-action="click->utils--icon-toggle#toggle"
+                data-bs-toggle="collapse"
+                data-bs-target="#download-repo-resolver"
+                title="Add new Datasource"
+                aria-label="<%= t('.button_browse_dataset_title') %>"
+                role="button"
+                aria-expanded="false"
+                aria-controls="download-repo-resolver"
+                class="btn btn-outline-secondary btn-sm">
+          <i data-utils--icon-toggle-target="icon" class="bi bi-plus-square-fill" aria-hidden="true"></i>
+          <span class="ps-1"><%= t('.button_browse_dataset_text') %></span>
+        </button>
+
+      </div>
+
     </div>
   </div>
 </div>

--- a/application/app/views/projects/show/_download_actions.html.erb
+++ b/application/app/views/projects/show/_download_actions.html.erb
@@ -19,20 +19,27 @@
         </div>
       </div>
 
-      <!-- edit workspace folder -->
-      <div data-controller="project-download-dir"
-           data-project-download-dir-browser-id-value="<%= file_browser_id %>">
-        <button type="button" class="btn btn-sm btn-outline-secondary"
-                data-controller="lazy-loader"
-                data-lazy-loader-container-id-value="<%= file_browser_id %>"
-                data-lazy-loader-url-value="<%= file_browser_path(path: project.download_dir) %>"
-                data-action="click->lazy-loader#load click->project-download-dir#open"
-                title="<%= t('.button_edit_download_dir_title') %>"
-                aria-label="<%= t('.button_edit_download_dir_label') %>">
-          <i class="bi bi-pencil-square" aria-hidden="true"></i>
-          <span class="visually-hidden"><%= t('.button_edit_download_dir_label') %></span>
-        </button>
-        <%= render partial: '/projects/show/edit_download_dir_modal', locals: { project: project, file_browser_id: file_browser_id } %>
+      <div class="d-flex align-items-center gap-2">
+        <!-- edit workspace folder -->
+        <div data-controller="project-download-dir"
+             data-project-download-dir-browser-id-value="<%= file_browser_id %>">
+          <button type="button" class="btn btn-sm btn-outline-secondary"
+                  data-controller="lazy-loader"
+                  data-lazy-loader-container-id-value="<%= file_browser_id %>"
+                  data-lazy-loader-url-value="<%= file_browser_path(path: project.download_dir) %>"
+                  data-action="click->lazy-loader#load click->project-download-dir#open"
+                  title="<%= t('.button_edit_download_dir_title') %>"
+                  aria-label="<%= t('.button_edit_download_dir_label') %>">
+            <i class="bi bi-pencil-square" aria-hidden="true"></i>
+            <span class="visually-hidden"><%= t('.button_edit_download_dir_label') %></span>
+          </button>
+          <%= render partial: '/projects/show/edit_download_dir_modal',
+                     locals: { project: project, file_browser_id: file_browser_id } %>
+        </div>
+
+        <!-- Open metadata link -->
+        <%= render partial: '/shared/metadata_folder_link',
+                   locals: { path: Project.download_files_directory(project.id) } %>
       </div>
     </div>
 

--- a/application/app/views/projects/show/_download_files.html.erb
+++ b/application/app/views/projects/show/_download_files.html.erb
@@ -2,7 +2,14 @@
 <div id="<%= tab_id_for(project) %>" class="tab-pane fade show active" role="tabpanel" aria-labelledby="<%= tab_label_for(project) %>">
   <%= render partial: '/projects/show/download_actions', locals: { project: project } %>
 
-  <%= render partial: '/layouts/repo_resolver_bar', locals: { id: 'download-repo-resolver', color: 'bg-light-darker', collapse: true, show_images: false } %>
+  <%= render partial: '/layouts/repo_resolver_bar',
+             locals: {
+               id: 'download-repo-resolver',
+               color: 'bg-light-darker',
+               collapse: true,
+               show_images: false,
+               url: repo_resolver_path(selected_project: project.id)
+             } %>
 
   <ul class="container files rounded border">
     <% if files.empty? %>

--- a/application/app/views/projects/show/_download_files.html.erb
+++ b/application/app/views/projects/show/_download_files.html.erb
@@ -8,7 +8,7 @@
                color: 'bg-light-darker',
                collapse: true,
                show_images: false,
-               url: repo_resolver_path(selected_project: project.id)
+               url: repo_resolver_path(from_project: project.id)
              } %>
 
   <ul class="container files rounded border">

--- a/application/app/views/projects/show/_project_actions.html.erb
+++ b/application/app/views/projects/show/_project_actions.html.erb
@@ -98,11 +98,6 @@
   </div>
 
   <!-- Open metadata link -->
-  <a href="<%= files_app_url(Project.project_metadata_dir(project.id)) %>"
-     target="_blank"
-     class="btn btn-sm btn-outline-secondary"
-     title="<%= t('.button_open_project_metadata_title') %>">
-    <i class="bi bi-card-list" aria-hidden="true"></i>
-    <span class="visually-hidden"><%= t('.button_open_project_metadata_title') %></span>
-  </a>
+  <%= render partial: '/shared/metadata_folder_link',
+             locals: { path: Project.project_metadata_dir(project.id) } %>
 </div>

--- a/application/app/views/shared/_metadata_folder_link.html.erb
+++ b/application/app/views/shared/_metadata_folder_link.html.erb
@@ -1,11 +1,11 @@
 <%
+  path = local_assigns.fetch(:path)
   text = local_assigns.fetch(:text, t('.button_open_folder_text'))
   title = local_assigns.fetch(:title, t('.button_open_folder_title'))
   classes = local_assigns.fetch(:class, 'btn btn-sm btn-outline-secondary')
-
 %>
 <!-- Open metadata link -->
-<a href="<%= files_app_url(Project.project_metadata_dir(project.id)) %>"
+<a href="<%= files_app_url(path) %>"
    target="_blank"
    class="<%= classes %>"
    title="<%= title %>">

--- a/application/app/views/shared/_metadata_folder_link.html.erb
+++ b/application/app/views/shared/_metadata_folder_link.html.erb
@@ -1,0 +1,14 @@
+<%
+  text = local_assigns.fetch(:text, t('.button_open_folder_text'))
+  title = local_assigns.fetch(:title, t('.button_open_folder_title'))
+  classes = local_assigns.fetch(:class, 'btn btn-sm btn-outline-secondary')
+
+%>
+<!-- Open metadata link -->
+<a href="<%= files_app_url(Project.project_metadata_dir(project.id)) %>"
+   target="_blank"
+   class="<%= classes %>"
+   title="<%= title %>">
+  <i class="bi bi-card-list" aria-hidden="true"></i>
+  <span class="visually-hidden"><%= text %></span>
+</a>

--- a/application/app/views/shared/_project_selection.html.erb
+++ b/application/app/views/shared/_project_selection.html.erb
@@ -10,7 +10,7 @@
               data-action="change->select-files-project#updateState">
         <% select_project_list.each do |project| %>
           <option value="<%= project.id %>" data-project-path="<%= project_path(project.id) %>">
-            <%= project.name %>
+            <%= select_project_list_name(project) %>
           </option>
         <% end %>
         <option value=""><%= t('.option_create_project_text') %></option>

--- a/application/config/locales/views/en.yml
+++ b/application/config/locales/views/en.yml
@@ -79,7 +79,6 @@ en:
       button_active_project_title: "Active Project"
       field_creation_date_title: "Creation date"
       link_open_downloads_title: "Open Project workspace folder"
-      link_open_metadata_title: "Open Project metadata folder"
     repo_resolver_bar:
       input_repo_url_placeholder: "Paste Repository URL"
       input_repo_url_label: "Repository URL"
@@ -121,7 +120,6 @@ en:
         button_delete_project_title: "Delete Project"
         button_open_project_folder_label: "Open Project workspace folder"
         button_open_project_folder_title: "Open Project workspace folder"
-        button_open_project_metadata_title: "Open Project metadata folder"
         field_creation_date_title: "Creation date"
         modal_delete_confirmation_title: "Delete Project"
         modal_delete_confirmation_content: "This will remove the project from the app. Files on disk and in remote repositories will remain untouched."
@@ -173,7 +171,6 @@ en:
         section_project_actions_label: "Project actions section"
         section_rename_project_label: "Rename project section"
       project_summary:
-        button_metadata_folder_title: "Open project metadata folder"
         button_toggle_label: "Project Summary"
         tab_download_label: "Download Files"
       project_summary_downloads:

--- a/application/config/locales/views/en.yml
+++ b/application/config/locales/views/en.yml
@@ -90,8 +90,10 @@ en:
       download_actions:
         button_open_downloads_folder_title: "Open Project workspace folder"
         header_download_files_text: "Downloads"
-        button_add_files_text: "Add Files"
-        button_add_files_title: "Add dataset to browse and select files"
+        button_add_files_text: "Select More Files"
+        button_add_files_title: "Select more files from the last repository dataset"
+        button_browse_dataset_text: "Add From URL"
+        button_browse_dataset_title: "Use a repository URL to to browse and select files from"
         button_edit_download_dir_title: "Update project workspace folder"
         button_edit_download_dir_label: "Update workspace folder"
       download_files:
@@ -219,6 +221,9 @@ en:
       button_submit_title: "Submit"
       button_cancel_title: "Cancel"
       spinner_loading_label: "Loading..."
+    metadata_folder_link:
+      button_open_folder_text: "Open metadata folder"
+      button_open_folder_title: "Open metadata folder in Open OnDemand"
     ood_folder_button:
       button_open_in_ondemand_title: "Open in OnDemand"
       image_ood_icon_alt: "Open OnDemand Icon"

--- a/application/test/connectors/dataverse/download_connector_metadata_test.rb
+++ b/application/test/connectors/dataverse/download_connector_metadata_test.rb
@@ -96,6 +96,6 @@ class Dataverse::ConnectorMetadataTest < ActiveSupport::TestCase
     assert_includes target.files_url, 'server_scheme=http'
     assert_includes target.files_url, 'server_port=8080'
     assert_includes target.files_url, 'version=2.0'
-    assert_includes target.files_url, 'selected_project=123'
+    assert_includes target.files_url, 'from_project=123'
   end
 end

--- a/application/test/connectors/dataverse/download_connector_metadata_test.rb
+++ b/application/test/connectors/dataverse/download_connector_metadata_test.rb
@@ -11,6 +11,7 @@ class Dataverse::ConnectorMetadataTest < ActiveSupport::TestCase
       test: 'anything value',
     }
     file = DownloadFile.new
+    file.project_id = '123'
     file.metadata = metadata
 
     target = Dataverse::DownloadConnectorMetadata.new(file)
@@ -35,6 +36,7 @@ class Dataverse::ConnectorMetadataTest < ActiveSupport::TestCase
       id: '12345'
     }
     file = DownloadFile.new
+    file.project_id = '123'
     file.metadata = metadata
 
     target = Dataverse::DownloadConnectorMetadata.new(file)
@@ -87,11 +89,13 @@ class Dataverse::ConnectorMetadataTest < ActiveSupport::TestCase
       version: '2.0'
     }
     file = DownloadFile.new
+    file.project_id = '123'
     file.metadata = metadata
 
     target = Dataverse::DownloadConnectorMetadata.new(file)
     assert_includes target.files_url, 'server_scheme=http'
     assert_includes target.files_url, 'server_port=8080'
     assert_includes target.files_url, 'version=2.0'
+    assert_includes target.files_url, 'selected_project=123'
   end
 end

--- a/application/test/connectors/dataverse/handlers/datasets_test.rb
+++ b/application/test/connectors/dataverse/handlers/datasets_test.rb
@@ -65,9 +65,7 @@ class Dataverse::Handlers::DatasetsTest < ActiveSupport::TestCase
 
     Project.stubs(:find).with('1').returns(nil)
     project = mock('project')
-    project.expects(:save).twice.returns(true)
-    dataset_url = Dataverse::Concerns::DataverseUrlBuilder.build_dataset_url(@repo_url.to_s, 'pid', version: '1')
-    project.expects(:add_repo).with(dataset_url)
+    project.expects(:save).returns(true)
     project.stubs(:name).returns('Proj')
     project.stubs(:id).returns('1')
 

--- a/application/test/connectors/zenodo/download_connector_metadata_test.rb
+++ b/application/test/connectors/zenodo/download_connector_metadata_test.rb
@@ -3,6 +3,7 @@ require 'test_helper'
 class Zenodo::DownloadConnectorMetadataTest < ActiveSupport::TestCase
   def setup
     file = DownloadFile.new
+    file.project_id = '123'
     file.metadata = {type: 'records', type_id: 1, zenodo_url: 'https://zenodo_server.com'}
     @meta = Zenodo::DownloadConnectorMetadata.new(file)
   end
@@ -12,7 +13,7 @@ class Zenodo::DownloadConnectorMetadataTest < ActiveSupport::TestCase
   end
 
   test 'files_url uses type and id' do
-    assert_equal '/explore/zenodo/zenodo_server.com/records/1', @meta.files_url
+    assert_equal '/explore/zenodo/zenodo_server.com/records/1?selected_project=123', @meta.files_url
   end
 
   test 'to_h and missing methods' do

--- a/application/test/connectors/zenodo/download_connector_metadata_test.rb
+++ b/application/test/connectors/zenodo/download_connector_metadata_test.rb
@@ -13,7 +13,7 @@ class Zenodo::DownloadConnectorMetadataTest < ActiveSupport::TestCase
   end
 
   test 'files_url uses type and id' do
-    assert_equal '/explore/zenodo/zenodo_server.com/records/1?selected_project=123', @meta.files_url
+    assert_equal '/explore/zenodo/zenodo_server.com/records/1?from_project=123', @meta.files_url
   end
 
   test 'to_h and missing methods' do

--- a/application/test/connectors/zenodo/handlers/records_test.rb
+++ b/application/test/connectors/zenodo/handlers/records_test.rb
@@ -36,9 +36,7 @@ class Zenodo::Handlers::RecordsTest < ActiveSupport::TestCase
 
     Project.stubs(:find).with('1').returns(nil)
     project = mock('project')
-    project.expects(:save).twice.returns(true)
-    record_url = Zenodo::Concerns::ZenodoUrlBuilder.build_record_url(@repo_url.server_url, '123')
-    project.expects(:add_repo).with(record_url)
+    project.expects(:save).returns(true)
     project.stubs(:name).returns('Proj')
     project.stubs(:id).returns(1)
 

--- a/application/test/controllers/application_controller_test.rb
+++ b/application/test/controllers/application_controller_test.rb
@@ -1,0 +1,51 @@
+require "test_helper"
+
+class ApplicationControllerTest < ActionController::TestCase
+  class DummyController < ApplicationController
+    skip_before_action :load_user_settings
+
+    def redirect_action
+      redirect_to "/redirected"
+    end
+
+    def success_action
+      render plain: Current.selected_project
+    end
+
+  end
+
+  tests DummyController
+
+  def setup
+    @routes = ActionDispatch::Routing::RouteSet.new
+    @routes.draw do
+      get "redirect_action" => "application_controller_test/dummy#redirect_action"
+      get "success_action" => "application_controller_test/dummy#success_action"
+    end
+
+    @request.env["action_dispatch.routes"] = @routes
+    Current.selected_project = nil
+    Current.settings = nil
+  end
+
+  test "sets flash redirect_params on redirect" do
+    get :redirect_action, params: { selected_project: "42", unsafe: "nope" }
+    assert_equal({ "selected_project" => "42" }, flash[:redirect_params])
+  end
+
+  test "does not set flash redirect_params without redirect" do
+    get :success_action, params: { selected_project: "42" }
+    assert_nil flash[:redirect_params]
+  end
+
+  test "sets Current attributes before action" do
+    get :success_action, params: { selected_project: "99" }
+    assert_equal "99", @response.body
+  end
+
+  test "uses flash redirect_params when params missing" do
+    get :success_action, flash: { redirect_params: { "selected_project" => "55" } }
+    assert_equal "55", @response.body
+  end
+
+end

--- a/application/test/controllers/application_controller_test.rb
+++ b/application/test/controllers/application_controller_test.rb
@@ -9,7 +9,7 @@ class ApplicationControllerTest < ActionController::TestCase
     end
 
     def success_action
-      render plain: Current.selected_project
+      render plain: Current.from_project
     end
 
   end
@@ -24,27 +24,27 @@ class ApplicationControllerTest < ActionController::TestCase
     end
 
     @request.env["action_dispatch.routes"] = @routes
-    Current.selected_project = nil
+    Current.from_project = nil
     Current.settings = nil
   end
 
   test "sets flash redirect_params on redirect" do
-    get :redirect_action, params: { selected_project: "42", unsafe: "nope" }
-    assert_equal({ "selected_project" => "42" }, flash[:redirect_params])
+    get :redirect_action, params: { from_project: "42", unsafe: "nope" }
+    assert_equal({ "from_project" => "42" }, flash[:redirect_params])
   end
 
   test "does not set flash redirect_params without redirect" do
-    get :success_action, params: { selected_project: "42" }
+    get :success_action, params: { from_project: "42" }
     assert_nil flash[:redirect_params]
   end
 
   test "sets Current attributes before action" do
-    get :success_action, params: { selected_project: "99" }
+    get :success_action, params: { from_project: "99" }
     assert_equal "99", @response.body
   end
 
   test "uses flash redirect_params when params missing" do
-    get :success_action, flash: { redirect_params: { "selected_project" => "55" } }
+    get :success_action, flash: { redirect_params: { "from_project" => "55" } }
     assert_equal "55", @response.body
   end
 

--- a/application/test/helpers/application_helper_test.rb
+++ b/application/test/helpers/application_helper_test.rb
@@ -40,6 +40,11 @@ class ApplicationHelperTest < ActionView::TestCase
     assert_equal 'alert alert-info', alert_class(:other)
   end
 
+  test 'flash_messages filters non-alert flash keys' do
+    messages = { notice: 'hi', foo: 'bar', error: 'ouch' }
+    assert_equal({ notice: 'hi', error: 'ouch' }, flash_messages(messages))
+  end
+
   test 'status_badge renders span with status text' do
     html = status_badge(FileStatus::SUCCESS, title: 'ok', filename: 'f')
     assert_includes html, 'badge file-status bg-success'

--- a/application/test/helpers/projects_helper_test.rb
+++ b/application/test/helpers/projects_helper_test.rb
@@ -44,6 +44,21 @@ class ProjectsHelperTest < ActionView::TestCase
     refute active_project?('456')
   end
 
+  test 'select_project_list_name appends active text for active project' do
+    project = OpenStruct.new(id: 1, name: 'Project A')
+    Current.settings = OpenStruct.new(user_settings: OpenStruct.new(active_project: '1'))
+    self.stubs(:t).with('helpers.projects.active_project_text').returns('Active')
+
+    assert_equal 'Project A (Active)', select_project_list_name(project)
+  end
+
+  test 'select_project_list_name returns name for inactive project' do
+    project = OpenStruct.new(id: 1, name: 'Project A')
+    Current.settings = OpenStruct.new(user_settings: OpenStruct.new(active_project: '2'))
+
+    assert_equal 'Project A', select_project_list_name(project)
+  end
+
   test 'select_project_list moves active project to top' do
     project1 = OpenStruct.new(id: 1, name: 'Project A')
     project2 = OpenStruct.new(id: 2, name: 'Project B')
@@ -79,6 +94,21 @@ class ProjectsHelperTest < ActionView::TestCase
     result = select_project_list
 
     assert_equal [project1, project2], result
+  end
+
+  test 'most_recent_explore_url returns nil when no files exist' do
+    project = OpenStruct.new(download_files: [])
+    assert_nil most_recent_explore_url(project)
+  end
+
+  test 'most_recent_explore_url returns url of most recent file' do
+    file_old = OpenStruct.new(end_date: '2023-01-01T00:00:00', start_date: nil, creation_date: nil,
+                              connector_metadata: OpenStruct.new(files_url: '/old'))
+    file_new = OpenStruct.new(end_date: '2023-01-02T00:00:00', start_date: nil, creation_date: nil,
+                              connector_metadata: OpenStruct.new(files_url: '/new'))
+    project = OpenStruct.new(download_files: [file_old, file_new])
+
+    assert_equal '/new', most_recent_explore_url(project)
   end
 
   test 'project_download_dir_browser_id returns id string' do

--- a/application/test/helpers/projects_helper_test.rb
+++ b/application/test/helpers/projects_helper_test.rb
@@ -44,7 +44,7 @@ class ProjectsHelperTest < ActionView::TestCase
     refute active_project?('456')
   end
 
-  test 'select_project_list moves active project to top and labels it' do
+  test 'select_project_list moves active project to top' do
     project1 = OpenStruct.new(id: 1, name: 'Project A')
     project2 = OpenStruct.new(id: 2, name: 'Project B')
     Project.stubs(:all).returns([project1, project2])
@@ -54,7 +54,6 @@ class ProjectsHelperTest < ActionView::TestCase
     result = select_project_list
 
     assert_equal [project2, project1], result
-    assert_equal 'Project B (Active)', result.first.name
   end
 
   test 'select_project_list prioritizes current project over active project' do
@@ -69,21 +68,6 @@ class ProjectsHelperTest < ActionView::TestCase
     result = select_project_list
 
     assert_equal [project3, project2, project1], result
-    assert_equal 'Project B (Active)', result[1].name
-  end
-
-  test 'select_project_list labels active project when it matches current project' do
-    project1 = OpenStruct.new(id: 1, name: 'Project A')
-    project2 = OpenStruct.new(id: 2, name: 'Project B')
-    Project.stubs(:all).returns([project1, project2])
-    Current.settings = OpenStruct.new(user_settings: OpenStruct.new(active_project: '2'))
-    self.stubs(:t).with('helpers.projects.active_project_text').returns('Active')
-
-    Current.from_project = '2'
-    result = select_project_list
-
-    assert_equal [project2, project1], result
-    assert_equal 'Project B (Active)', result.first.name
   end
 
   test 'select_project_list returns original order if no active match' do

--- a/application/test/helpers/projects_helper_test.rb
+++ b/application/test/helpers/projects_helper_test.rb
@@ -6,12 +6,12 @@ class ProjectsHelperTest < ActionView::TestCase
 
   setup do
     @original_settings = Current.settings
-    @original_selected_project = Current.selected_project
+    @original_from_project = Current.from_project
   end
 
   teardown do
     Current.settings = @original_settings
-    Current.selected_project = @original_selected_project
+    Current.from_project = @original_from_project
   end
 
   test 'header and border classes respond to active' do
@@ -65,7 +65,7 @@ class ProjectsHelperTest < ActionView::TestCase
     Current.settings = OpenStruct.new(user_settings: OpenStruct.new(active_project: '2'))
     self.stubs(:t).with('helpers.projects.active_project_text').returns('Active')
 
-    Current.selected_project = '3'
+    Current.from_project = '3'
     result = select_project_list
 
     assert_equal [project3, project2, project1], result
@@ -79,7 +79,7 @@ class ProjectsHelperTest < ActionView::TestCase
     Current.settings = OpenStruct.new(user_settings: OpenStruct.new(active_project: '2'))
     self.stubs(:t).with('helpers.projects.active_project_text').returns('Active')
 
-    Current.selected_project = '2'
+    Current.from_project = '2'
     result = select_project_list
 
     assert_equal [project2, project1], result

--- a/application/test/models/project_test.rb
+++ b/application/test/models/project_test.rb
@@ -8,12 +8,6 @@ class ProjectTest < ActiveSupport::TestCase
     assert_equal 'test_project', target.name
     assert_equal '/tmp/test_project', target.download_dir
     assert_not_nil target.creation_date
-    assert_equal [], target.repo_urls
-  end
-
-  test "initializer stores empty repo_urls when nil provided" do
-    target = create_valid_project(repo_urls: nil)
-    assert_equal [], target.repo_urls
   end
 
   test "should be valid when all fields are populated" do
@@ -115,7 +109,6 @@ class ProjectTest < ActiveSupport::TestCase
       assert_equal 'ab12345', saved_project.id
       assert_equal 'test_project', saved_project.name
       assert_equal '/tmp/test_project', saved_project.download_dir
-      assert_equal [], saved_project.repo_urls
     end
   end
 
@@ -135,7 +128,6 @@ class ProjectTest < ActiveSupport::TestCase
       assert_equal target2.id, saved_project.id
       assert_equal target2.name, saved_project.name
       assert_equal target2.download_dir, saved_project.download_dir
-      assert_equal [], saved_project.repo_urls
     end
   end
 
@@ -155,7 +147,6 @@ class ProjectTest < ActiveSupport::TestCase
       assert_equal 'ab12345', saved_project.id
       assert_equal 'test_project', saved_project.name
       assert_equal '/tmp/test_project', saved_project.download_dir
-      assert_equal [], saved_project.repo_urls
     end
   end
 
@@ -272,46 +263,14 @@ class ProjectTest < ActiveSupport::TestCase
     end
   end
 
-  test "repo_urls default to empty and add_repo handles MRU" do
-    target = create_valid_project
-    assert_equal [], target.repo_urls
-
-    target.add_repo('http://example.com/one')
-    target.add_repo('http://example.com/two')
-    target.add_repo('http://example.com/one')
-
-    assert_equal ['http://example.com/one', 'http://example.com/two'], target.repo_urls
-  end
-
-  test "add_repo enforces max of 20 repo_urls" do
-    target = create_valid_project
-    urls = (1..21).map { |i| "http://example.com/repo#{i}" }
-    urls.each { |u| target.add_repo(u) }
-
-    assert_equal 20, target.repo_urls.size
-    assert_equal urls.last(20).reverse, target.repo_urls
-  end
-
-  test "repo_urls persist when saved" do
-    in_temp_directory do
-      target = create_valid_project
-      target.add_repo('http://example.com/a')
-      target.add_repo('http://example.com/b')
-      assert target.save
-
-      saved = Project.find(target.id)
-      assert_equal ['http://example.com/b', 'http://example.com/a'], saved.repo_urls
-    end
-  end
-
   private
 
-  def create_valid_project(id: 'ab12345', name: 'test_project', download_dir: '/tmp/test_project', repo_urls: [])
-    Project.new(id: id, name: name, download_dir: download_dir, repo_urls: repo_urls)
+  def create_valid_project(id: 'ab12345', name: 'test_project', download_dir: '/tmp/test_project')
+    Project.new(id: id, name: name, download_dir: download_dir)
   end
 
   def project_hash(project)
-    {id: project.id, name: project.name, download_dir: project.download_dir, creation_date: project.creation_date, repo_urls: project.repo_urls}.stringify_keys
+    {id: project.id, name: project.name, download_dir: project.download_dir, creation_date: project.creation_date}.stringify_keys
   end
 
   def in_temp_directory
@@ -324,3 +283,4 @@ class ProjectTest < ActiveSupport::TestCase
   end
 
 end
+

--- a/application/test/services/common/file_sorter_test.rb
+++ b/application/test/services/common/file_sorter_test.rb
@@ -69,5 +69,28 @@ module Common
       shuffled = expected.shuffle(random: Random.new(1))
       assert_equal expected, @sorter.most_relevant(shuffled)
     end
+
+    test 'most_recent sorts files by available date descending' do
+      times = (1..4).map { |i| format('2023-01-%02dT00:00:00', i) }
+
+      end_date_file = create_download_file(@project)
+      end_date_file.end_date = times[3]
+
+      start_date_file = create_download_file(@project)
+      start_date_file.start_date = times[2]
+
+      creation_date_file = create_download_file(@project)
+      creation_date_file.creation_date = times[1]
+
+      no_date_file = create_download_file(@project)
+      no_date_file.end_date = nil
+      no_date_file.start_date = nil
+      no_date_file.creation_date = nil
+
+      expected = [end_date_file, start_date_file, creation_date_file, no_date_file]
+      shuffled = expected.shuffle(random: Random.new(1))
+
+      assert_equal expected, @sorter.most_recent(shuffled)
+    end
   end
 end

--- a/application/test/views/layouts/flash_messages_view_test.rb
+++ b/application/test/views/layouts/flash_messages_view_test.rb
@@ -1,0 +1,14 @@
+# frozen_string_literal: true
+
+require 'test_helper'
+
+class FlashMessagesViewTest < ActionView::TestCase
+  test 'renders only allowed flash keys' do
+    flash[:notice] = 'hello'
+    flash[:foo] = 'bar'
+
+    html = render partial: 'layouts/flash_messages'
+    assert_includes html, 'hello'
+    refute_includes html, 'bar'
+  end
+end

--- a/application/test/views/layouts/repo_resolver_bar_view_test.rb
+++ b/application/test/views/layouts/repo_resolver_bar_view_test.rb
@@ -1,0 +1,16 @@
+# frozen_string_literal: true
+
+require 'test_helper'
+
+class RepoResolverBarViewTest < ActionView::TestCase
+  test 'defaults url to repo_resolver_path' do
+    html = render partial: 'layouts/repo_resolver_bar', locals: { show_images: false }
+    assert_includes html, "action=\"#{repo_resolver_path}\""
+  end
+
+  test 'allows overriding url' do
+    custom_url = '/custom/path'
+    html = render partial: 'layouts/repo_resolver_bar', locals: { url: custom_url, show_images: false }
+    assert_includes html, "action=\"#{custom_url}\""
+  end
+end

--- a/application/test/views/projects/download_files_view_test.rb
+++ b/application/test/views/projects/download_files_view_test.rb
@@ -3,7 +3,7 @@
 require 'test_helper'
 
 class DownloadFilesViewTest < ActionView::TestCase
-  test 'passes selected project to repo resolver bar' do
+  test 'passes from project to repo resolver bar' do
     project = Project.new(name: 'test_project')
     project.stubs(:download_files).returns([])
 
@@ -21,7 +21,7 @@ class DownloadFilesViewTest < ActionView::TestCase
 
     html = render partial: 'projects/show/download_files', locals: { project: project }
 
-    expected_url = repo_resolver_path(selected_project: project.id)
+    expected_url = repo_resolver_path(from_project: project.id)
     assert_includes html, "action=\"#{expected_url}\""
   end
 end

--- a/application/test/views/projects/download_files_view_test.rb
+++ b/application/test/views/projects/download_files_view_test.rb
@@ -1,0 +1,28 @@
+# frozen_string_literal: true
+
+require 'test_helper'
+
+class DownloadFilesViewTest < ActionView::TestCase
+  test 'passes selected project to repo resolver bar' do
+    project = Project.new(name: 'test_project')
+    project.stubs(:download_files).returns([])
+
+    view.stubs(:tab_id_for).with(project).returns('tab-id')
+    view.stubs(:tab_label_for).with(project).returns('tab-label')
+
+    original_render = view.method(:render)
+    view.define_singleton_method(:render) do |*args, &block|
+      if args.first.is_a?(Hash) && args.first[:partial] == '/projects/show/download_actions'
+        ''
+      else
+        original_render.call(*args, &block)
+      end
+    end
+
+    html = render partial: 'projects/show/download_files', locals: { project: project }
+
+    expected_url = repo_resolver_path(selected_project: project.id)
+    assert_includes html, "action=\"#{expected_url}\""
+  end
+end
+


### PR DESCRIPTION
## Description
Project pre-selected when clicking through the project details page to a explore page.

Before the preselected project was the latest created or the active project.

## Related Issue
related to #405 

## Testing
- [x] Added/updated tests
- [x] All tests pass locally
- [x] Tested manually (describe how)

## Documentation
- [ ] Updated relevant documentation
- [x] No documentation changes needed