### PR TITLE
feat: Added reset feature to delete all application metadata

### DIFF
--- a/application/app/javascript/controllers/modal_controller.js
+++ b/application/app/javascript/controllers/modal_controller.js
@@ -2,7 +2,7 @@ import { Controller } from "@hotwired/stimulus"
 import { showFlash } from 'utils/flash_message'
 
 export default class extends Controller {
-    static targets = ["title", "subtitle", "content", "spinner", "confirmButton", "confirmText"]
+    static targets = ["title", "subtitle", "content", "spinner", "confirmText"]
     static values = { url: String, id: String, title: String }
 
     connect() {

--- a/application/app/javascript/controllers/utils/link_confirmation_controller.js
+++ b/application/app/javascript/controllers/utils/link_confirmation_controller.js
@@ -1,0 +1,49 @@
+import { Controller } from "@hotwired/stimulus"
+import { showFlash } from 'utils/flash_message'
+
+export default class extends Controller {
+    static targets = ["form"]
+
+    static values = {
+        modalId: String,
+        modalTitle: String,
+        modalSubtitle: String,
+        modalContent: String,
+        modalConfirmText: String
+    }
+
+    click(event) {
+        event.preventDefault()
+
+        if (!this.hasModalIdValue) {
+            showFlash('error', `Invalid configuration. Unable to proceed.`)
+            return
+        }
+
+        const modalElement = document.getElementById(this.modalIdValue)
+        const modalController = this.application.getControllerForElementAndIdentifier(modalElement, 'modal')
+
+        if (modalController) {
+            modalController.updateContent({
+                title: this.modalTitleValue,
+                subtitle: this.modalSubtitleValue,
+                content: this.modalContentValue,
+                confirmText: this.modalConfirmTextValue,
+                onConfirm: () => this.continueRequest()
+            })
+        } else {
+            showFlash('error', `No confirmation message. Unable to proceed.`)
+        }
+    }
+
+    continueRequest() {
+        const href = this.element.getAttribute("href")
+        if (this.hasFormTarget) {
+            this.formTarget.requestSubmit()
+        } else if (href) {
+            window.location.href = href
+        } else {
+            showFlash('error', 'No action defined for this confirmation.')
+        }
+    }
+}

--- a/application/app/services/reset_service.rb
+++ b/application/app/services/reset_service.rb
@@ -8,12 +8,17 @@ class ResetService
 
   # Deletes the metadata root directory configured for the application.
   def reset
+    log_info('Resetting...')
     metadata_root = Configuration.metadata_root
-    log_info('Deleting metadata directory', path: metadata_root)
+    detached_process_lock = Configuration.detached_process_lock_file
+    command_server_socket = Configuration.command_server_socket_file
+    log_info('Deleting metadata files', { root: metadata_root, detached_process_lock: detached_process_lock, command_server_socket: command_server_socket })
+    FileUtils.rm_f(command_server_socket)
+    FileUtils.rm_f(detached_process_lock)
     FileUtils.rm_rf(metadata_root)
-    log_info('Deleted metadata directory', path: metadata_root)
+    log_info('Deleted metadata files', { root: metadata_root, detached_process_lock: detached_process_lock, command_server_socket: command_server_socket })
   rescue StandardError => e
-    log_error('Failed to delete metadata directory', { path: metadata_root }, e)
+    log_error('Failed to reset application state', { root: metadata_root, detached_process_lock: detached_process_lock, command_server_socket: command_server_socket }, e)
     raise
   end
 end

--- a/application/app/services/reset_service.rb
+++ b/application/app/services/reset_service.rb
@@ -1,0 +1,19 @@
+# frozen_string_literal: true
+
+require 'fileutils'
+
+# ResetService removes the application metadata directory.
+class ResetService
+  include LoggingCommon
+
+  # Deletes the metadata root directory configured for the application.
+  def reset
+    metadata_root = Configuration.metadata_root
+    log_info('Deleting metadata directory', path: metadata_root)
+    FileUtils.rm_rf(metadata_root)
+    log_info('Deleted metadata directory', path: metadata_root)
+  rescue StandardError => e
+    log_error('Failed to delete metadata directory', { path: metadata_root }, e)
+    raise
+  end
+end

--- a/application/app/views/layouts/_modal_delete_confirmation.html.erb
+++ b/application/app/views/layouts/_modal_delete_confirmation.html.erb
@@ -33,9 +33,9 @@
           </p>
 
           <div class="d-flex justify-content-center gap-4">
-            <button type="submit" class="btn btn-danger w-25" data-modal-target="confirm_button" data-action="modal#confirm">
+            <button type="submit" class="btn btn-danger w-25" data-action="modal#confirm">
               <i class="bi bi-trash me-1" aria-hidden="true"></i>
-              <span data-modal-target="confirm_text"><%= t('.button_confirm_text') %></span>
+              <span data-modal-target="confirmText"><%= t('.button_confirm_text') %></span>
             </button>
             <button type="button" class="btn btn-secondary w-25" data-bs-dismiss="modal">
               <%= t('.button_cancel_text') %>

--- a/application/app/views/layouts/nav/_navigation.html.erb
+++ b/application/app/views/layouts/nav/_navigation.html.erb
@@ -1,28 +1,49 @@
-<nav class="navbar navbar-expand-lg shadow-sm bg-dark" data-bs-theme="dark">
+<nav class="navbar navbar-expand-lg shadow-sm bg-dark" data-bs-theme="dark" aria-label="Main navigation">
   <div class="container-fluid">
     <%= render partial: 'layouts/nav/logo' %>
-    <button class="navbar-toggler" type="button" data-bs-toggle="collapse" data-bs-target="#navbarSupportedContent" aria-controls="navbarSupportedContent" aria-expanded="false" aria-label="Toggle navigation">
+
+    <!-- Mobile toggle button -->
+    <button class="navbar-toggler" type="button"
+            data-bs-toggle="collapse"
+            data-bs-target="#navbarSupportedContent"
+            aria-controls="navbarSupportedContent"
+            aria-expanded="false"
+            aria-label="Toggle navigation">
       <span class="navbar-toggler-icon"></span>
     </button>
+
     <div class="collapse navbar-collapse" id="navbarSupportedContent">
-      <ul class="navbar-nav me-auto mb-2 mb-lg-0" role="menubar">
-        <li class="nav-item" role="menuitem">
-          <%= nav_link_to t(".link_projects_text"), projects_path, class: 'nav-link' %>
+      <!-- Primary nav links -->
+      <ul class="navbar-nav me-auto mb-2 mb-lg-0">
+        <li class="nav-item">
+          <%= nav_link_to t(".link_projects_text"), projects_path, class: 'nav-link', aria: { current: 'page' } %>
         </li>
-        <li class="nav-item" role="menuitem">
+        <li class="nav-item">
           <%= nav_link_to t(".link_downloads_text"), download_status_path, class: 'nav-link' %>
         </li>
-        <li class="nav-item" role="menuitem">
+        <li class="nav-item">
           <%= nav_link_to t(".link_uploads_text"), upload_status_path, class: 'nav-link' %>
         </li>
+
+        <!-- Dropdown: Repositories -->
         <li class="nav-item dropdown">
-          <a class="nav-link dropdown-toggle" href="#" role="button" data-bs-toggle="dropdown" aria-expanded="false">
+          <a class="nav-link dropdown-toggle"
+             href="#"
+             id="repositoriesDropdown"
+             role="button"
+             data-bs-toggle="dropdown"
+             aria-expanded="false"
+             aria-haspopup="true"
+             aria-controls="repositoriesMenu">
             <%= t(".link_repositories_text") %>
           </a>
-          <ul class="dropdown-menu">
-            <li role="menuitem">
-              <a class="dropdown-item d-flex align-items-center gap-2" href="<%= link_to_landing(ConnectorType::DATAVERSE) %>">
-                <span class="icon-wrapper bg-white rounded d-inline-flex align-items-center justify-content-center p-1">
+          <ul class="dropdown-menu"
+              id="repositoriesMenu"
+              aria-labelledby="repositoriesDropdown">
+            <li>
+              <a class="dropdown-item d-flex align-items-center gap-2"
+                 href="<%= link_to_landing(ConnectorType::DATAVERSE) %>">
+                <span class="icon-wrapper bg-white rounded d-inline-flex align-items-center justify-content-center p-1" aria-hidden="true">
                   <%= connector_icon(ConnectorType::DATAVERSE) %>
                 </span>
                 <%= t('.link_dataverse_text') %>
@@ -30,20 +51,23 @@
             </li>
 
             <% if ::Configuration.zenodo_enabled %>
-              <li role="menuitem">
-                <a class="dropdown-item d-flex align-items-center gap-2" href="<%= explore_path(connector_type: ConnectorType::ZENODO.to_s, server_domain: Zenodo::ZenodoUrl::DEFAULT_SERVER, object_type: 'landing', object_id: ':root') %>">
-                  <span class="icon-wrapper bg-white rounded d-inline-flex align-items-center justify-content-center p-1">
+              <li>
+                <a class="dropdown-item d-flex align-items-center gap-2"
+                   href="<%= explore_path(connector_type: ConnectorType::ZENODO.to_s, server_domain: Zenodo::ZenodoUrl::DEFAULT_SERVER, object_type: 'landing', object_id: ':root') %>">
+                  <span class="icon-wrapper bg-white rounded d-inline-flex align-items-center justify-content-center p-1" aria-hidden="true">
                     <%= connector_icon(ConnectorType::ZENODO) %>
                   </span>
                   <%= t('.link_zenodo_text') %>
                 </a>
               </li>
             <% end %>
-            <li><hr class="dropdown-divider"></li>
-            <li role="menuitem">
+
+            <li><hr class="dropdown-divider" role="separator"></li>
+
+            <li>
               <%= nav_link_to repository_settings_path, class: 'dropdown-item d-flex align-items-center gap-2' do %>
-                <span class="icon-wrapper bg-white text-dark rounded d-inline-flex align-items-center justify-content-center p-1">
-                  <i class="bi bi-gear-fill" aria-hidden="true"></i>
+                <span class="icon-wrapper bg-white text-dark rounded d-inline-flex align-items-center justify-content-center p-1" aria-hidden="true">
+                  <i class="bi bi-gear-fill"></i>
                 </span>
                 <%= t('.link_repo_settings_text') %>
               <% end %>
@@ -51,56 +75,98 @@
           </ul>
         </li>
       </ul>
-      <ul class="navbar-nav ms-auto" role="menubar"> <!-- ms-auto pushes this section to the right -->
-        <li class="nav-item" role="menuitem">
+
+      <!-- Right-aligned nav -->
+      <ul class="navbar-nav ms-auto">
+        <li class="nav-item">
           <%= nav_link_to ood_dashboard_url, class: 'nav-link d-flex align-items-center' do %>
-            <%= image_tag('ood_icon.svg', alt: t('.icon_ood_alt'), class: 'icon-class me-1') %> Open OnDemand
+            <%= image_tag('ood_icon.svg',
+                          alt: t('.icon_ood_alt'),
+                          class: 'icon-class me-1') %>
+            Open OnDemand
           <% end %>
         </li>
+
+        <!-- Dropdown: Help -->
         <li class="nav-item dropdown">
-          <a class="nav-link dropdown-toggle" href="#" role="button" data-bs-toggle="dropdown" aria-expanded="false">
+          <a class="nav-link dropdown-toggle"
+             href="#"
+             id="helpDropdown"
+             role="button"
+             data-bs-toggle="dropdown"
+             aria-expanded="false"
+             aria-haspopup="true"
+             aria-controls="helpMenu">
             <%= t(".link_help_text") %>
           </a>
-          <ul class="dropdown-menu">
-            <li role="menuitem">
-              <a class="dropdown-item d-flex align-items-center gap-2" href="<%= guide_url %>" target="_blank">
-                <span class="icon-wrapper icon-wrapper bg-white text-dark rounded d-inline-flex align-items-center justify-content-center p-1">
-                  <i class="bi bi-book" aria-hidden="true"></i>
+          <ul class="dropdown-menu dropdown-menu-end"
+              id="helpMenu"
+              aria-labelledby="helpDropdown">
+            <li>
+              <a class="dropdown-item d-flex align-items-center gap-2" href="<%= guide_url %>" target="_blank" rel="noopener">
+                <span class="icon-wrapper bg-white text-dark rounded d-inline-flex align-items-center justify-content-center p-1" aria-hidden="true">
+                  <i class="bi bi-book"></i>
                 </span>
                 <%= t(".link_guide_text") %>
               </a>
             </li>
-            <li role="menuitem">
-              <a class="dropdown-item d-flex align-items-center gap-2" href="<%= sitemap_path %>" target="_blank">
-                <span class="icon-wrapper icon-wrapper bg-white text-dark rounded d-inline-flex align-items-center justify-content-center p-1">
-                  <i class="bi bi-diagram-3" aria-hidden="true"></i>
+            <li>
+              <a class="dropdown-item d-flex align-items-center gap-2" href="<%= sitemap_path %>" target="_blank" rel="noopener">
+                <span class="icon-wrapper bg-white text-dark rounded d-inline-flex align-items-center justify-content-center p-1" aria-hidden="true">
+                  <i class="bi bi-diagram-3"></i>
                 </span>
                 <%= t(".link_sitemap_text") %>
               </a>
             </li>
-            <li role="menuitem">
+            <li>
               <a class="dropdown-item d-flex align-items-center gap-2" href="<%= restart_url %>">
-                <span class="icon-wrapper icon-wrapper bg-white text-dark rounded d-inline-flex align-items-center justify-content-center p-1">
-                  <i class="bi bi-bootstrap-reboot" aria-hidden="true"></i>
+                <span class="icon-wrapper bg-white text-dark rounded d-inline-flex align-items-center justify-content-center p-1" aria-hidden="true">
+                  <i class="bi bi-bootstrap-reboot"></i>
                 </span>
                 <%= t(".link_restart_text") %>
               </a>
+            </li>
+            <li><hr class="dropdown-divider"></li>
+            <li>
+              <% # RESET BUTTON WITH CONFIRMATION MESSAGE  %>
+              <%= button_to widgets_path('reset'),
+                    method: :post,
+                    form: { data: {
+                      controller: "utils--link-confirmation",
+                      "utils--link-confirmation-target": "form",
+                      "utils--link-confirmation-modal-id-value": "modal-delete-confirmation",
+                      "utils--link-confirmation-modal-title-value": t('.reset_confirmation_title'),
+                      "utils--link-confirmation-modal-subtitle-value": t('.reset_confirmation_subtitle'),
+                      "utils--link-confirmation-modal-content-value": t('.reset_confirmation_content'),
+                      "utils--link-confirmation-modal-confirm-text-value": t('.reset_confirmation_button_text')
+                    } },
+                    data: { action: "click->utils--link-confirmation#click" },
+                    class: "dropdown-item d-flex align-items-center gap-2" do %>
+                <span class="icon-wrapper bg-white text-dark rounded d-inline-flex align-items-center justify-content-center p-1" aria-hidden="true">
+                  <i class="bi bi-exclamation-octagon-fill"></i>
+                </span>
+                <%= t(".link_reset_text") %>
+              <% end %>
             </li>
           </ul>
         </li>
       </ul>
     </div>
 
+    <!-- Process status -->
     <div id="process-status"
          data-controller="lazy-loader"
          aria-live="polite"
+         aria-label="Background process status"
          data-lazy-loader-url-value="<%= detached_process_status_path %>"
          data-lazy-loader-stop-on-inactive-value="true"
          data-lazy-loader-interval-value="<%= ::Configuration.detached_process_status_interval %>">
       <div id="file-activity-status"
            class="d-flex justify-content-center align-items-start py-2"
            style="min-width: 100px; height: 100%;">
-        <span class="text-light spinner-border spinner-border-sm" role="status" aria-hidden="true"></span>
+        <span class="text-light spinner-border spinner-border-sm"
+              role="status"
+              aria-label="Loading process status"></span>
       </div>
     </div>
   </div>

--- a/application/app/views/layouts/nav/_navigation.html.erb
+++ b/application/app/views/layouts/nav/_navigation.html.erb
@@ -157,7 +157,7 @@
     <div id="process-status"
          data-controller="lazy-loader"
          aria-live="polite"
-         aria-label="Background process status"
+         aria-label="<%= t(".detached_process_widget_label") %>"
          data-lazy-loader-url-value="<%= detached_process_status_path %>"
          data-lazy-loader-stop-on-inactive-value="true"
          data-lazy-loader-interval-value="<%= ::Configuration.detached_process_status_interval %>">
@@ -166,7 +166,7 @@
            style="min-width: 100px; height: 100%;">
         <span class="text-light spinner-border spinner-border-sm"
               role="status"
-              aria-label="Loading process status"></span>
+              aria-label="<%= t(".detached_process_spinner_label") %>"></span>
       </div>
     </div>
   </div>

--- a/application/app/views/projects/index.html.erb
+++ b/application/app/views/projects/index.html.erb
@@ -18,12 +18,21 @@
       <% if @projects.empty? %>
         <div class="alert bg-primary-subtle mt-4">
           <h4 class="alert-heading"><i class="bi bi-info-circle me-2" aria-hidden="true"></i><%= t('.welcome_title').html_safe %></h4>
-          <p><%= t('.welcome_message_html') %></p>
+          <div class="mt-3">
+            <%= t('.welcome_message_html') %>
+          </div>
           <p class="pt-3 text-center">
             <%= link_to t('.button_welcome_text'), guide_url, class: 'btn btn-primary', target: '_blank' %>
           </p>
         </div>
-      <% end %>
+
+        <div class="alert alert-warning border-2 rounded-3 shadow-sm" role="alert">
+          <h4 class="alert-heading"><i class="bi bi-exclamation-triangle me-2" aria-hidden="true"></i><%= t('.beta_notice_title').html_safe %></h4>
+          <div class="mt-3">
+            <%= t('.beta_notice_html') %>
+          </div>
+        </div>
+    <% end %>
     </div>
   </div>
 

--- a/application/app/views/widgets/_reset.html.erb
+++ b/application/app/views/widgets/_reset.html.erb
@@ -4,7 +4,7 @@
 <!DOCTYPE html>
 <html>
 <head>
-  <title><%= valid_reset_request ? "Reset Completed" : "Invalid Reset Request" %></title>
+  <title><%= valid_reset_request ? t('.success_page_title') : t('.error_page_title') %></title>
   <meta name="viewport" content="width=device-width, initial-scale=1">
   <%= stylesheet_link_tag "application" %>
   <%= javascript_include_tag "application", defer: true %>
@@ -20,13 +20,8 @@
         <% ResetService.new.reset %>
         <div class="alert alert-success border-2 rounded-3 shadow-sm text-center" role="alert">
           <i class="bi bi-check-circle-fill fs-3 text-success mb-2"></i>
-          <h4 class="alert-heading">Reset Completed</h4>
-          <p>Your personal <em>OnDemand Loop</em> instance has been successfully reset.</p>
-          <p>The application will automatically restart in <strong>3 seconds</strong>.</p>
-          <hr>
-          <p class="mb-0">
-            If the page does not refresh, <a href="<%= restart_url %>">click here to continue</a>.
-          </p>
+          <h4 class="alert-heading"><%= t('.success_content_title') %></h4>
+          <%= t('.success_content_html', url: restart_url) %>
         </div>
         <!-- Success redirect -->
         <script>
@@ -37,13 +32,8 @@
       <% else %>
         <div class="alert alert-danger border-2 rounded-3 shadow-sm text-center" role="alert">
           <i class="bi bi-exclamation-octagon-fill fs-3 text-danger mb-2"></i>
-          <h4 class="alert-heading">Invalid Request</h4>
-          <p>The reset request is only allowed via POST.</p>
-          <p>You will be redirected to the home page in <strong>3 seconds</strong>.</p>
-          <hr>
-          <p class="mb-0">
-            If the page does not refresh, <a href="<%= root_path %>">click here to continue</a>.
-          </p>
+          <h4 class="alert-heading"><%= t('.error_content_title') %></h4>
+          <%= t('.error_content_html', url: root_path) %>
         </div>
         <!-- Error redirect -->
         <script>

--- a/application/app/views/widgets/_reset.html.erb
+++ b/application/app/views/widgets/_reset.html.erb
@@ -1,0 +1,59 @@
+<%
+  valid_reset_request = request.post?
+%>
+<!DOCTYPE html>
+<html>
+<head>
+  <title><%= valid_reset_request ? "Reset Completed" : "Invalid Reset Request" %></title>
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <%= stylesheet_link_tag "application" %>
+  <%= javascript_include_tag "application", defer: true %>
+
+  <!-- Meta refresh fallback -->
+  <meta http-equiv="refresh" content="3;url=<%= root_path %>">
+</head>
+<body class="bg-light d-flex justify-content-center align-items-center vh-100">
+<div class="container">
+  <div class="row justify-content-center">
+    <div class="col-md-8 col-lg-6">
+      <% if valid_reset_request %>
+        <% ResetService.new.reset %>
+        <div class="alert alert-success border-2 rounded-3 shadow-sm text-center" role="alert">
+          <i class="bi bi-check-circle-fill fs-3 text-success mb-2"></i>
+          <h4 class="alert-heading">Reset Completed</h4>
+          <p>Your personal <em>OnDemand Loop</em> instance has been successfully reset.</p>
+          <p>The application will automatically restart in <strong>3 seconds</strong>.</p>
+          <hr>
+          <p class="mb-0">
+            If the page does not refresh, <a href="<%= restart_url %>">click here to continue</a>.
+          </p>
+        </div>
+        <!-- Success redirect -->
+        <script>
+            setTimeout(function() {
+                window.location.href = "<%= restart_url %>";
+            }, 3000);
+        </script>
+      <% else %>
+        <div class="alert alert-danger border-2 rounded-3 shadow-sm text-center" role="alert">
+          <i class="bi bi-exclamation-octagon-fill fs-3 text-danger mb-2"></i>
+          <h4 class="alert-heading">Invalid Request</h4>
+          <p>The reset request is only allowed via POST.</p>
+          <p>You will be redirected to the home page in <strong>3 seconds</strong>.</p>
+          <hr>
+          <p class="mb-0">
+            If the page does not refresh, <a href="<%= root_path %>">click here to continue</a>.
+          </p>
+        </div>
+        <!-- Error redirect -->
+        <script>
+            setTimeout(function() {
+                window.location.href = "<%= root_path %>";
+            }, 3000);
+        </script>
+      <% end %>
+    </div>
+  </div>
+</div>
+</body>
+</html>

--- a/application/config/locales/views/en.yml
+++ b/application/config/locales/views/en.yml
@@ -61,6 +61,11 @@ en:
         link_guide_text: "Guide"
         link_sitemap_text: "Sitemap"
         link_restart_text: "Restart"
+        link_reset_text: "Reset Application"
+        reset_confirmation_title: "Confirm Reset"
+        reset_confirmation_subtitle: "This action cannot be undone"
+        reset_confirmation_content: "This will remove all projects and file metadata from the app, returning it to a brand new state. Files on disk and in remote repositories will remain untouched."
+        reset_confirmation_button_text: "Reset"
     flash_messages:
       button_close_label: "Close"
     footer:
@@ -190,6 +195,16 @@ en:
         <p>This project has been funded by <a href="https://adminops.fas.harvard.edu/FAS-HUIT-PRB" target="_blank">FAS-HUIT Project Review Board (PRB) initiative</a>.</p>
         <p>Start by creating a project with the <strong>Create Project</strong> button above.</p>
       button_welcome_text: "Read the Guide"
+      beta_notice_title: "Beta Notice"
+      beta_notice_html: >
+        <p><strong>OnDemand Loop</strong> is currently in <strong>Beta</strong> status. While we strive to provide a stable experience, please be aware of the following:</p>
+        <ul class="mb-0">
+        <li>You may encounter occasional bugs or incomplete features.</li>
+        <li>User interface and workflow changes may occur without backward compatibility guarantees.</li>
+        <li>Minor UI/UX inconsistencies are expected as the product evolves.</li>
+        <li>If you encounter errors or inconsistencies, you can try using the <strong>Help → Reset</strong> option to return your instance to a clean state.</li>
+        <li>We welcome <a href="https://github.com/IQSS/ondemand-loop/issues" target="_blank">feedback and bug reports</a> to help us improve!</li>
+        </ul>
   shared:
     breadcrumbs:
       home: "Home"

--- a/application/config/locales/views/en.yml
+++ b/application/config/locales/views/en.yml
@@ -66,6 +66,8 @@ en:
         reset_confirmation_subtitle: "This action cannot be undone"
         reset_confirmation_content: "This will remove all projects and file metadata from the app, returning it to a brand new state. Files on disk and in remote repositories will remain untouched."
         reset_confirmation_button_text: "Reset"
+        detached_process_widget_label: "Detached process status widget"
+        detached_process_spinner_label: "Detached process status loading"
     flash_messages:
       button_close_label: "Close"
     footer:
@@ -294,3 +296,22 @@ en:
       section_item_actions_label: "Item actions"
       button_explore_item_title: "Browse repository"
       button_open_repository_title: "Open repository on website"
+    reset:
+      success_page_title: "Reset Completed"
+      success_content_title: "Reset Completed"
+      success_content_html: >
+        <p>Your personal <em>OnDemand Loop</em> instance has been successfully reset.</p>
+        <p>The application will automatically restart in <strong>3 seconds</strong>.</p>
+        <hr>
+        <p class="mb-0">
+        If the page does not refresh, <a href="%{url}">click here to continue</a>.
+        </p>
+      error_page_title: "Invalid Reset Request"
+      error_content_title: "Invalid Request"
+      error_content_html: >
+        <p>The reset request is only allowed via POST.</p>
+        <p>You will be redirected to the home page in <strong>3 seconds</strong>.</p>
+        <hr>
+        <p class="mb-0">
+        If the page does not refresh, <a href="%{url}">click here to continue</a>.
+        </p>

--- a/application/config/routes.rb
+++ b/application/config/routes.rb
@@ -52,8 +52,8 @@ Rails.application.routes.draw do
   get '/detached_process/status', to: 'detached_process#status'
   # FILE BROWSER
   get '/file_browser', to: 'file_browser#index'
-  #WIDGETS
-  get '/widgets/*widget_path', to: 'widgets#show', via: [:get], as: 'widgets'
+  # WIDGETS
+  match '/widgets/*widget_path', to: 'widgets#show', via: [:get, :post], as: 'widgets'
   # SITEMAP
   get '/sitemap' => 'sitemap#index', as: :sitemap
 

--- a/application/test/services/reset_service_test.rb
+++ b/application/test/services/reset_service_test.rb
@@ -4,7 +4,16 @@ require 'test_helper'
 class ResetServiceTest < ActiveSupport::TestCase
   def setup
     @tmp_dir = Dir.mktmpdir
+    @lock_file = File.join(@tmp_dir, 'lock_file')
+    @socket_file = File.join(@tmp_dir, 'command.server.sock')
+
+    File.write(@lock_file, 'lock')
+    File.write(@socket_file, 'socket')
+
     Configuration.stubs(:metadata_root).returns(@tmp_dir)
+    Configuration.stubs(:detached_process_lock_file).returns(@lock_file)
+    Configuration.stubs(:command_server_socket_file).returns(@socket_file)
+
     FileUtils.mkdir_p(@tmp_dir)
   end
 
@@ -12,13 +21,19 @@ class ResetServiceTest < ActiveSupport::TestCase
     FileUtils.rm_rf(@tmp_dir) if Dir.exist?(@tmp_dir)
   end
 
-  test 'reset deletes metadata directory' do
+  test 'reset deletes metadata directory and files' do
     test_file = File.join(@tmp_dir, 'some_file')
     File.write(test_file, 'data')
 
     assert Dir.exist?(@tmp_dir)
+    assert File.exist?(@lock_file)
+    assert File.exist?(@socket_file)
+
     ResetService.new.reset
+
     refute Dir.exist?(@tmp_dir)
+    refute File.exist?(@lock_file)
+    refute File.exist?(@socket_file)
   end
 
   test 'logs error when deletion fails' do
@@ -32,6 +47,6 @@ class ResetServiceTest < ActiveSupport::TestCase
 
     assert Dir.exist?(@tmp_dir)
     assert_equal 1, reset_service.logged_messages.size
-    assert_match 'Failed to delete metadata directory', reset_service.logged_messages.first[:message]
+    assert_match 'Failed to reset application state', reset_service.logged_messages.first[:message]
   end
 end

--- a/application/test/services/reset_service_test.rb
+++ b/application/test/services/reset_service_test.rb
@@ -1,0 +1,37 @@
+# frozen_string_literal: true
+require 'test_helper'
+
+class ResetServiceTest < ActiveSupport::TestCase
+  def setup
+    @tmp_dir = Dir.mktmpdir
+    Configuration.stubs(:metadata_root).returns(@tmp_dir)
+    FileUtils.mkdir_p(@tmp_dir)
+  end
+
+  def teardown
+    FileUtils.rm_rf(@tmp_dir) if Dir.exist?(@tmp_dir)
+  end
+
+  test 'reset deletes metadata directory' do
+    test_file = File.join(@tmp_dir, 'some_file')
+    File.write(test_file, 'data')
+
+    assert Dir.exist?(@tmp_dir)
+    ResetService.new.reset
+    refute Dir.exist?(@tmp_dir)
+  end
+
+  test 'logs error when deletion fails' do
+    reset_service = ResetService.new
+    reset_service.extend(LoggingCommonMock)
+
+    FileUtils.stubs(:rm_rf).raises(StandardError, 'boom')
+
+    assert_raises(StandardError) { reset_service.reset }
+    FileUtils.unstub(:rm_rf)
+
+    assert Dir.exist?(@tmp_dir)
+    assert_equal 1, reset_service.logged_messages.size
+    assert_match 'Failed to delete metadata directory', reset_service.logged_messages.first[:message]
+  end
+end

--- a/application/test/views/widgets/reset_partial_test.rb
+++ b/application/test/views/widgets/reset_partial_test.rb
@@ -1,0 +1,34 @@
+# frozen_string_literal: true
+require 'test_helper'
+
+class ResetPartialTest < ActionView::TestCase
+
+  def render_with(method: :post)
+    request = ActionDispatch::TestRequest.create
+    request.request_method = method.to_s.upcase
+
+    view.stubs(:request).returns(request)
+    view.stubs(:restart_url).returns('/restart')
+    view.stubs(:root_path).returns('/')
+
+    render partial: 'widgets/reset'
+  end
+
+  test 'renders success when request is POST' do
+    html = render_with(method: :post)
+
+    assert_includes html, 'Reset Completed'
+    assert_includes html, 'successfully reset'
+    assert_includes html, 'window.location.href = "/restart"'
+    assert_includes html, 'bi-check-circle-fill'
+  end
+
+  test 'renders error when request is GET' do
+    html = render_with(method: :get)
+
+    assert_includes html, 'Invalid Request'
+    assert_includes html, 'only allowed via POST'
+    assert_includes html, 'window.location.href = "/"'
+    assert_includes html, 'bi-exclamation-octagon-fill'
+  end
+end


### PR DESCRIPTION
## Description
Feature to delete all application metadata and allow for a fresh start.
This is in case there are new changes that are not backwards compatible and users are required to clean up existing data to allow for the new code to work correctly

## Related Issue
Fixes #422 

## Testing
- [x] Added/updated tests
- [x] All tests pass locally
- [ ] Tested manually (describe how)

## Documentation
- [ ] Updated relevant documentation
- [ ] No documentation changes needed