### PR TITLE
fix: Improvements to detached process management

### DIFF
--- a/application/app/process/detached_process.rb
+++ b/application/app/process/detached_process.rb
@@ -11,26 +11,18 @@ class DetachedProcess
     @start_time = Time.now
     @command_server = nil
     @services = []
+    @lock_file = Configuration.detached_process_lock_file
+    setup_cleanup_handlers
   end
 
   def launch
-    log_info('Process launched', {pid: process_id})
-
-    lock_file = ::Configuration.detached_process_lock_file
-    File.open(lock_file, 'w') do |service_lock|
-      unless service_lock.flock(File::LOCK_EX | File::LOCK_NB) # Exclusive, non-blocking lock
-        log_info('Exit. Other DetachedProcess already running', {pid: process_id})
-        return
-      end
-
-      startup
-
-      log_info('Completed', {pid: process_id, elapsed_time: elapsed_time})
-    rescue => e
-      log_error('Exit. Error while executing DetachedProcess', {pid: process_id, elapsed_time: elapsed_time}, e)
-    ensure
-      shutdown
-    end
+    log_info('Process launched', { pid: process_id, lock_file: @lock_file })
+    startup
+    log_info('Completed', { pid: process_id, elapsed_time: elapsed_time })
+  rescue => e
+    log_error('Exit. Error while executing DetachedProcess', { pid: process_id, elapsed_time: elapsed_time }, e)
+  ensure
+    shutdown
   end
 
   private
@@ -54,4 +46,29 @@ class DetachedProcess
     elapsed_string(@start_time)
   end
 
+  def setup_cleanup_handlers
+    # Clean up lock file when process exits normally or abnormally
+    at_exit do
+      cleanup_lock_file
+    end
+
+    # Handle signals gracefully (TERM, INT, QUIT, HUP)
+    %w[TERM INT QUIT HUP].each do |signal|
+      Signal.trap(signal) do
+        log_info("Received #{signal}, shutting down gracefully...", { pid: process_id })
+        cleanup_lock_file
+        exit(0)
+      end
+    end
+  end
+
+  def cleanup_lock_file
+    return unless @lock_file && File.exist?(@lock_file)
+
+    File.delete(@lock_file)
+    log_info("Lock file cleaned up", { pid: process_id, lock_file: @lock_file })
+  rescue => e
+    # Log error but don't raise to avoid masking the original exit reason
+    log_error("Could not clean up lock file", { pid: process_id, lock_file: @lock_file }, e)
+  end
 end

--- a/application/app/process/script_launcher.rb
+++ b/application/app/process/script_launcher.rb
@@ -2,6 +2,7 @@
 
 class ScriptLauncher
   include LoggingCommon
+  include DateTimeCommon
   LAUNCH_SCRIPT = 'scripts/launch_detached_process.rb'
 
   def initialize(download_files_provider, upload_files_provider)
@@ -10,11 +11,25 @@ class ScriptLauncher
   end
 
   def launch_script
-    if pending_files?
-      log_info("Launching Detached Process Script...")
-      start_process_from_script(LAUNCH_SCRIPT, 'launch_detached_process.log')
-    else
-      log_info("No pending files - skipping")
+    return log_info('No pending files - skipping') unless pending_files?
+
+    lock_file = Configuration.detached_process_lock_file
+    File.open(lock_file, File::CREAT | File::RDWR) do |service_lock|
+      if service_lock.flock(File::LOCK_EX | File::LOCK_NB)
+        if process_already_running?(service_lock)
+          log_info('Skip. DetachedProcess already running', { lock_file: lock_file })
+        else
+          log_info("Launching Detached Process Script...", { lock_file: lock_file })
+          spawn_pid = start_process_from_script(LAUNCH_SCRIPT, 'launch_detached_process.log')
+
+          # Write PID and timestamp to lock file while we have the lock
+          update_lock_file(service_lock, spawn_pid)
+
+          log_info("DetachedProcess started", { pid: spawn_pid, lock_file: lock_file, started_at: now })
+        end
+      else
+        log_info('Skip. Another request is processing the lock', { lock_file: lock_file })
+      end
     end
   end
 
@@ -35,5 +50,56 @@ class ScriptLauncher
       pgroup: true
     )
     Process.detach(pid)
+    pid
+  end
+
+  private
+
+  def process_already_running?(file)
+    file.rewind
+    content = file.read.strip
+    return false if content.empty?
+
+    lines = content.split("\n")
+    return false if lines.length < 2
+
+    pid = lines[0].to_i
+    timestamp_str = lines[1].strip
+    timestamp = to_time(timestamp_str)
+
+    # GIVE TIME FOR THE DETACHED PROCESS TO START
+    # ONLY CHECK PROCESS IF AT LEAST 60s HAS ELAPSED
+    return true if elapsed(timestamp) < 60
+
+    # Check if process actually exists
+    begin
+      Process.getpgid(pid)
+      log_info("Found running DetachedProcess", {
+        pid: pid,
+        started_at: timestamp_str,
+        running_for: elapsed_string(timestamp)
+      })
+      true
+    rescue Errno::ESRCH
+      log_info("Stale lock file detected - process no longer exists", {
+        pid: pid,
+        was_started_at: timestamp_str,
+        was_running_for: elapsed_string(timestamp)
+      })
+      false
+    rescue => e
+      log_warn("Error checking process status", { pid: pid, error: e.message })
+      false
+    end
+  end
+
+  def update_lock_file(file, pid)
+    file.rewind
+    file.write("#{pid}\n#{now}")
+    file.flush
+    file.truncate(file.pos)
+  rescue => e
+    log_error("Failed to update lock file", { pid: pid, error: e.message })
+    raise
   end
 end

--- a/application/app/services/command/command_client.rb
+++ b/application/app/services/command/command_client.rb
@@ -15,8 +15,7 @@ module Command
     def request(request, timeout: 1)
       socket = nil
       unless File.exist?(@socket_path)
-        log_error('Socket file not found', { socket: @socket_path })
-        return Response.error(status: 521, message: 'Socket file not found')
+        return Response.error(status: 521, message: 'Socket file not found. Server not running')
       end
 
       log_info('Sending command', { socket: @socket_path, command: request.command })

--- a/application/test/process/detached_process_test.rb
+++ b/application/test/process/detached_process_test.rb
@@ -4,69 +4,231 @@ require 'test_helper'
 
 class DetachedProcessTest < ActiveSupport::TestCase
   setup do
-    @tmpdir = Dir.mktmpdir
-    @mock_lock_file = File.join(@tmpdir, 'detached.process.lock').to_s
-    Configuration.stubs(:metadata_root).returns(@tmpdir.to_s)
-    Configuration.stubs(:download_server_socket_file).returns(File.join(@tmpdir, 'mock.socket').to_s)
+    @tmpdir = Dir.mktmpdir('detached_process_test')
+    @mock_lock_file = File.join(@tmpdir, 'detached.process.lock')
+    @mock_socket_file = File.join(@tmpdir, 'command_server.socket')
+
+    Configuration.stubs(:metadata_root).returns(@tmpdir)
+    Configuration.stubs(:detached_process_lock_file).returns(@mock_lock_file)
+    Configuration.stubs(:command_server_socket_file).returns(@mock_socket_file)
+
+    # Reset any existing signal handlers to avoid interference
+    %w[TERM INT QUIT HUP].each { |sig| Signal.trap(sig, 'DEFAULT') }
   end
 
-  def teardown
+  teardown do
     FileUtils.remove_entry(@tmpdir) if File.directory?(@tmpdir)
+    # Reset signal handlers
+    %w[TERM INT QUIT HUP].each { |sig| Signal.trap(sig, 'DEFAULT') }
   end
 
-  test 'launch starts controller, services, command server and logs process lifecycle' do
-    # Stub services and controller
-    command_server = mock('CommandServer')
-    command_server.expects(:start).once
-    command_server.expects(:shutdown).once
-
-    controller = mock('DetachedProcessController')
-    controller.expects(:run).once
-
-    DetachedProcessManager.stubs(:new).returns(controller)
-    Command::CommandServer.stubs(:new).returns(command_server)
-    Download::DownloadService.stubs(:new)
-    Upload::UploadService.stubs(:new)
-
+  test 'initialize sets up process attributes and cleanup handlers' do
     process = DetachedProcess.new
-
-    File.delete(@mock_lock_file) if File.exist?(@mock_lock_file)
-
-    process.launch
 
     assert_equal Process.pid, process.process_id
+    assert_not_nil process.instance_variable_get(:@start_time)
+    assert_equal @mock_lock_file, process.instance_variable_get(:@lock_file)
+    assert_empty process.instance_variable_get(:@services)
   end
 
-  test 'launch exits early if lock is already held' do
-    File.open(@mock_lock_file, 'w') do |f|
-      f.flock(File::LOCK_EX | File::LOCK_NB) # Simulate existing lock
+  test 'launch starts services, command server and logs process lifecycle' do
+    # Mock dependencies
+    command_server = mock('CommandServer')
+    command_server.expects(:start).once
+    command_server.expects(:shutdown).once
 
-      process = DetachedProcess.new
+    controller = mock('DetachedProcessManager')
+    controller.expects(:run).once
 
-      # Expect nothing else to be initialized
-      Command::CommandServer.expects(:new).never
-      DetachedProcessManager.expects(:new).never
+    download_service = mock('DownloadService')
+    upload_service = mock('UploadService')
 
-      process.launch
-    end
+    # Stub constructors
+    Command::CommandServer.expects(:new).with(socket_path: @mock_socket_file).returns(command_server)
+    DetachedProcessManager.expects(:new).returns(controller)
+    Download::DownloadService.expects(:new).returns(download_service)
+    Upload::UploadService.expects(:new).returns(upload_service)
+
+    process = DetachedProcess.new
+
+    # Mock logging expectations
+    process.expects(:log_info).with('Process launched', { pid: Process.pid, lock_file: @mock_lock_file })
+    process.expects(:log_info).with('Completed', { pid: Process.pid, elapsed_time: anything })
+
+    process.launch
   end
 
-  test 'launch still shuts down command server if error raised during startup' do
+  test 'launch handles startup errors gracefully and still shuts down' do
     command_server = mock('CommandServer')
     command_server.expects(:start).once
     command_server.expects(:shutdown).once
 
     Command::CommandServer.stubs(:new).returns(command_server)
-
-    Download::DownloadService.stubs(:new).raises(StandardError, 'Startup failure')
-    Upload::UploadService.stubs(:new)
+    Download::DownloadService.expects(:new).raises(StandardError, 'Startup failure')
 
     process = DetachedProcess.new
 
-    File.delete(@mock_lock_file) if File.exist?(@mock_lock_file)
+    # Expect error logging
+    process.expects(:log_info).with('Process launched', { pid: Process.pid, lock_file: @mock_lock_file })
+    process.expects(:log_error).with('Exit. Error while executing DetachedProcess',
+                                     { pid: Process.pid, elapsed_time: anything },
+                                     instance_of(StandardError))
 
+    # Should not raise, error is handled
     assert_nothing_raised do
       process.launch
     end
+  end
+
+  test 'cleanup_lock_file removes lock file when it exists' do
+    # Create a mock lock file
+    File.write(@mock_lock_file, "test content")
+    assert File.exist?(@mock_lock_file)
+
+    process = DetachedProcess.new
+    process.expects(:log_info).with("Lock file cleaned up", { pid: Process.pid, lock_file: @mock_lock_file })
+
+    process.send(:cleanup_lock_file)
+
+    assert_not File.exist?(@mock_lock_file)
+  end
+
+  test 'cleanup_lock_file handles missing lock file gracefully' do
+    # Ensure lock file doesn't exist
+    File.delete(@mock_lock_file) if File.exist?(@mock_lock_file)
+
+    process = DetachedProcess.new
+    process.expects(:log_info).never
+    process.expects(:log_error).never
+
+    # Should not raise error
+    assert_nothing_raised do
+      process.send(:cleanup_lock_file)
+    end
+  end
+
+  test 'cleanup_lock_file handles file deletion errors' do
+    # Create a lock file
+    File.write(@mock_lock_file, "test content")
+
+    # Make the file undeletable by stubbing File.delete to raise error
+    File.expects(:delete).with(@mock_lock_file).raises(Errno::EACCES, 'Permission denied')
+
+    process = DetachedProcess.new
+    process.expects(:log_error).with("Could not clean up lock file",
+                                     { pid: Process.pid, lock_file: @mock_lock_file },
+                                     instance_of(Errno::EACCES))
+
+    # Should not raise error
+    assert_nothing_raised do
+      process.send(:cleanup_lock_file)
+    end
+  end
+
+  test 'signal handlers are set up correctly' do
+    original_handlers = {}
+    %w[TERM INT QUIT HUP].each { |sig| original_handlers[sig] = Signal.trap(sig, 'DEFAULT') }
+
+    process = DetachedProcess.new
+
+    # Verify signal handlers are installed (they should not be 'DEFAULT' anymore)
+    %w[TERM INT QUIT HUP].each do |signal|
+      current_handler = Signal.trap(signal, 'DEFAULT')
+      assert_not_equal 'DEFAULT', current_handler
+      # Restore the handler for cleanup
+      Signal.trap(signal, current_handler) if current_handler
+    end
+  end
+
+  test 'cleanup functionality works correctly' do
+    # Test the cleanup logic directly instead of through signal handlers
+    File.write(@mock_lock_file, "test content")
+
+    process = DetachedProcess.new
+    process.expects(:log_info).with("Lock file cleaned up", { pid: Process.pid, lock_file: @mock_lock_file })
+
+    # Test cleanup_lock_file directly
+    process.send(:cleanup_lock_file)
+
+    assert_not File.exist?(@mock_lock_file)
+  end
+
+  test 'at_exit handler is set up' do
+    # This is tricky to test directly since we can't easily trigger at_exit in tests
+    # We can verify the handler calls cleanup_lock_file by mocking
+
+    File.write(@mock_lock_file, "test content")
+
+    process = DetachedProcess.new
+
+    # The at_exit block should be registered, we can't easily test its execution
+    # but we can test that cleanup_lock_file works when called directly
+    process.expects(:log_info).with("Lock file cleaned up", { pid: Process.pid, lock_file: @mock_lock_file })
+
+    process.send(:cleanup_lock_file)
+  end
+
+  test 'elapsed_time returns formatted duration' do
+    start_time = Time.parse('2025-08-28T14:30:00')
+
+    process = DetachedProcess.new
+    process.instance_variable_set(:@start_time, start_time)
+
+    # Mock the elapsed_string method from DateTimeCommon
+    process.expects(:elapsed_string).with(start_time).returns('00:05:30')
+
+    assert_equal '00:05:30', process.send(:elapsed_time)
+  end
+
+  test 'shutdown only shuts down command server' do
+    command_server = mock('CommandServer')
+    command_server.expects(:shutdown).once
+
+    process = DetachedProcess.new
+    process.instance_variable_set(:@command_server, command_server)
+
+    process.send(:shutdown)
+  end
+
+  test 'shutdown handles nil command server gracefully' do
+    process = DetachedProcess.new
+    process.instance_variable_set(:@command_server, nil)
+
+    # Should not raise error
+    assert_nothing_raised do
+      process.send(:shutdown)
+    end
+  end
+
+  test 'services are properly initialized during startup' do
+    # Mock all dependencies to avoid actual initialization
+    command_server = mock('CommandServer')
+    command_server.expects(:start)
+    command_server.expects(:shutdown)
+
+    controller = mock('DetachedProcessManager')
+    controller.stubs(:run)
+
+    download_files_provider = mock('DownloadFilesProvider')
+    upload_files_provider = mock('UploadFilesProvider')
+    download_service = mock('DownloadService')
+    upload_service = mock('UploadService')
+
+    Command::CommandServer.stubs(:new).returns(command_server)
+    DetachedProcessManager.stubs(:new).returns(controller)
+    Download::DownloadFilesProvider.expects(:new).returns(download_files_provider)
+    Upload::UploadFilesProvider.expects(:new).returns(upload_files_provider)
+    Download::DownloadService.expects(:new).with(download_files_provider).returns(download_service)
+    Upload::UploadService.expects(:new).with(upload_files_provider).returns(upload_service)
+
+    process = DetachedProcess.new
+    process.stubs(:log_info) # Suppress logging for this test
+
+    process.launch
+
+    services = process.instance_variable_get(:@services)
+    assert_includes services, download_service
+    assert_includes services, upload_service
+    assert_equal 2, services.length
   end
 end

--- a/application/test/process/script_launcher_test.rb
+++ b/application/test/process/script_launcher_test.rb
@@ -6,22 +6,16 @@ class ScriptLauncherTest < ActiveSupport::TestCase
     @download_files_provider = mock('DownloadFilesProvider')
     @upload_files_provider = mock('UploadFilesProvider')
     @launcher = ScriptLauncher.new(@download_files_provider, @upload_files_provider)
+
+    # Create a temporary directory and lock file path
+    @temp_dir = Dir.mktmpdir('script_launcher_test')
+    @lock_file_path = File.join(@temp_dir, 'detached_process.lock')
+    Configuration.stubs(:detached_process_lock_file).returns(@lock_file_path)
   end
 
-  test 'launch_script starts process if there are pending download files' do
-    @download_files_provider.stubs(:pending_files).returns(['file1'])
-    @upload_files_provider.stubs(:pending_files).returns([])
-
-    @launcher.expects(:start_process_from_script).with('scripts/launch_detached_process.rb', 'launch_detached_process.log')
-    @launcher.launch_script
-  end
-
-  test 'launch_script starts process if there are pending upload files' do
-    @download_files_provider.stubs(:pending_files).returns([])
-    @upload_files_provider.stubs(:pending_files).returns(['file1'])
-
-    @launcher.expects(:start_process_from_script).with('scripts/launch_detached_process.rb', 'launch_detached_process.log')
-    @launcher.launch_script
+  teardown do
+    # Clean up the entire temporary directory
+    FileUtils.remove_entry(@temp_dir) if @temp_dir && Dir.exist?(@temp_dir)
   end
 
   test 'launch_script logs info and does not start process if no pending files' do
@@ -30,6 +24,174 @@ class ScriptLauncherTest < ActiveSupport::TestCase
 
     @launcher.expects(:start_process_from_script).never
     @launcher.expects(:log_info).with('No pending files - skipping')
+    @launcher.launch_script
+  end
+
+  test 'launch_script starts process if there are pending download files and no lock' do
+    @download_files_provider.stubs(:pending_files).returns(['file1'])
+    @upload_files_provider.stubs(:pending_files).returns([])
+
+    @launcher.expects(:start_process_from_script).with('scripts/launch_detached_process.rb', 'launch_detached_process.log').returns(12345)
+    @launcher.expects(:log_info).with("Launching Detached Process Script...", { lock_file: @lock_file_path })
+    @launcher.expects(:log_info).with("DetachedProcess started", {
+      pid: 12345,
+      lock_file: @lock_file_path,
+      started_at: anything
+    })
+    @launcher.stubs(:now).returns('2025-08-28T14:30:45')
+
+    @launcher.launch_script
+
+    # Verify lock file was created with correct content
+    assert File.exist?(@lock_file_path)
+    content = File.read(@lock_file_path)
+    lines = content.split("\n")
+    assert_equal '12345', lines[0]
+    assert_equal '2025-08-28T14:30:45', lines[1]
+  end
+
+  test 'launch_script starts process if there are pending upload files and no lock' do
+    @download_files_provider.stubs(:pending_files).returns([])
+    @upload_files_provider.stubs(:pending_files).returns(['file1'])
+
+    @launcher.expects(:start_process_from_script).with('scripts/launch_detached_process.rb', 'launch_detached_process.log').returns(12345)
+    @launcher.expects(:log_info).with("Launching Detached Process Script...", { lock_file: @lock_file_path })
+    @launcher.expects(:log_info).with("DetachedProcess started", {
+      pid: 12345,
+      lock_file: @lock_file_path,
+      started_at: anything
+    })
+    @launcher.stubs(:now).returns('2025-08-28T14:30:45')
+
+    @launcher.launch_script
+  end
+
+  test 'launch_script skips if process is already running (within 60s grace period)' do
+    @download_files_provider.stubs(:pending_files).returns(['file1'])
+    @upload_files_provider.stubs(:pending_files).returns([])
+
+    # Create a lock file with recent timestamp (within 60s)
+    File.write(@lock_file_path, "12345\n2025-08-28T14:30:45")
+    @launcher.stubs(:to_time).with('2025-08-28T14:30:45').returns(Time.parse('2025-08-28T14:30:45'))
+    @launcher.stubs(:elapsed).with(Time.parse('2025-08-28T14:30:45')).returns(30) # 30 seconds ago
+
+    @launcher.expects(:start_process_from_script).never
+    @launcher.expects(:log_info).with('Skip. DetachedProcess already running', { lock_file: @lock_file_path })
+
+    @launcher.launch_script
+  end
+
+  test 'launch_script skips if process is running and exists after 60s' do
+    @download_files_provider.stubs(:pending_files).returns(['file1'])
+    @upload_files_provider.stubs(:pending_files).returns([])
+
+    # Create a lock file with older timestamp (> 60s)
+    File.write(@lock_file_path, "12345\n2025-08-28T14:30:45")
+    @launcher.stubs(:to_time).with('2025-08-28T14:30:45').returns(Time.parse('2025-08-28T14:30:45'))
+    @launcher.stubs(:elapsed).with(Time.parse('2025-08-28T14:30:45')).returns(120) # 2 minutes ago
+    @launcher.stubs(:elapsed_string).with(Time.parse('2025-08-28T14:30:45')).returns('00:02:00')
+
+    # Mock that process exists
+    Process.expects(:getpgid).with(12345).returns(12345)
+
+    @launcher.expects(:start_process_from_script).never
+    @launcher.expects(:log_info).with('Skip. DetachedProcess already running', { lock_file: @lock_file_path })
+    @launcher.expects(:log_info).with("Found running DetachedProcess", {
+      pid: 12345,
+      started_at: '2025-08-28T14:30:45',
+      running_for: '00:02:00'
+    })
+
+    @launcher.launch_script
+  end
+
+  test 'launch_script starts new process if old process no longer exists' do
+    @download_files_provider.stubs(:pending_files).returns(['file1'])
+    @upload_files_provider.stubs(:pending_files).returns([])
+
+    # Create a lock file with older timestamp (> 60s)
+    File.write(@lock_file_path, "12345\n2025-08-28T14:30:45")
+    @launcher.stubs(:to_time).with('2025-08-28T14:30:45').returns(Time.parse('2025-08-28T14:30:45'))
+    @launcher.stubs(:elapsed).with(Time.parse('2025-08-28T14:30:45')).returns(120) # 2 minutes ago
+    @launcher.stubs(:elapsed_string).with(Time.parse('2025-08-28T14:30:45')).returns('00:02:00')
+    @launcher.stubs(:now).returns('2025-08-28T14:32:45')
+
+    # Mock that process doesn't exist
+    Process.expects(:getpgid).with(12345).raises(Errno::ESRCH)
+
+    @launcher.expects(:start_process_from_script).with('scripts/launch_detached_process.rb', 'launch_detached_process.log').returns(67890)
+    @launcher.expects(:log_info).with("Stale lock file detected - process no longer exists", {
+      pid: 12345,
+      was_started_at: '2025-08-28T14:30:45',
+      was_running_for: '00:02:00'
+    })
+    @launcher.expects(:log_info).with("Launching Detached Process Script...", { lock_file: @lock_file_path })
+    @launcher.expects(:log_info).with("DetachedProcess started", {
+      pid: 67890,
+      lock_file: @lock_file_path,
+      started_at: '2025-08-28T14:32:45'
+    })
+
+    @launcher.launch_script
+  end
+
+  test 'launch_script skips if another request is processing (flock fails)' do
+    @download_files_provider.stubs(:pending_files).returns(['file1'])
+    @upload_files_provider.stubs(:pending_files).returns([])
+
+    # Simulate another process holding the lock
+    File.open(@lock_file_path, File::CREAT | File::RDWR) do |other_lock|
+      other_lock.flock(File::LOCK_EX)
+
+      @launcher.expects(:start_process_from_script).never
+      @launcher.expects(:log_info).with('Skip. Another request is processing the lock', { lock_file: @lock_file_path })
+
+      # This should timeout quickly due to LOCK_NB
+      @launcher.launch_script
+    end
+  end
+
+  test 'launch_script handles empty lock file' do
+    @download_files_provider.stubs(:pending_files).returns(['file1'])
+    @upload_files_provider.stubs(:pending_files).returns([])
+
+    # Create empty lock file
+    File.write(@lock_file_path, '')
+
+    @launcher.expects(:start_process_from_script).with('scripts/launch_detached_process.rb', 'launch_detached_process.log').returns(12345)
+    @launcher.stubs(:now).returns('2025-08-28T14:30:45')
+
+    @launcher.launch_script
+  end
+
+  test 'launch_script handles malformed lock file' do
+    @download_files_provider.stubs(:pending_files).returns(['file1'])
+    @upload_files_provider.stubs(:pending_files).returns([])
+
+    # Create malformed lock file (only one line)
+    File.write(@lock_file_path, '12345')
+
+    @launcher.expects(:start_process_from_script).with('scripts/launch_detached_process.rb', 'launch_detached_process.log').returns(67890)
+    @launcher.stubs(:now).returns('2025-08-28T14:30:45')
+
+    @launcher.launch_script
+  end
+
+  test 'launch_script handles Process.getpgid errors gracefully' do
+    @download_files_provider.stubs(:pending_files).returns(['file1'])
+    @upload_files_provider.stubs(:pending_files).returns([])
+
+    File.write(@lock_file_path, "12345\n2025-08-28T14:30:45")
+    @launcher.stubs(:to_time).with('2025-08-28T14:30:45').returns(Time.parse('2025-08-28T14:30:45'))
+    @launcher.stubs(:elapsed).with(Time.parse('2025-08-28T14:30:45')).returns(120)
+
+    # Mock unexpected error
+    Process.expects(:getpgid).with(12345).raises(StandardError, 'Unexpected error')
+
+    @launcher.expects(:log_warn).with("Error checking process status", { pid: 12345, error: 'Unexpected error' })
+    @launcher.expects(:start_process_from_script).with('scripts/launch_detached_process.rb', 'launch_detached_process.log').returns(67890)
+    @launcher.stubs(:now).returns('2025-08-28T14:32:45')
+
     @launcher.launch_script
   end
 
@@ -53,13 +215,32 @@ class ScriptLauncherTest < ActiveSupport::TestCase
     Configuration.stubs(:ruby_binary).returns('ruby')
     Configuration.stubs(:metadata_root).returns('/tmp')
     Process.expects(:spawn).with('ruby', 'script.rb',
-      out: ['/tmp/log.log', 'a'],
-      err: ['/tmp/log.log', 'a'],
-      in: '/dev/null',
-      pgroup: true
+                                 out: ['/tmp/log.log', 'a'],
+                                 err: ['/tmp/log.log', 'a'],
+                                 in: '/dev/null',
+                                 pgroup: true
     ).returns(123)
     Process.expects(:detach).with(123)
 
-    @launcher.start_process_from_script('script.rb', 'log.log')
+    result = @launcher.start_process_from_script('script.rb', 'log.log')
+    assert_equal 123, result
+  end
+
+  test 'update_lock_file handles write errors' do
+    @download_files_provider.stubs(:pending_files).returns(['file1'])
+    @upload_files_provider.stubs(:pending_files).returns([])
+
+    @launcher.stubs(:now).returns('2025-08-28T14:30:45')
+
+    # Mock file operations to simulate write error
+    mock_file = mock('file')
+    mock_file.expects(:rewind)
+    mock_file.expects(:write).raises(IOError, 'Disk full')
+
+    @launcher.expects(:log_error).with("Failed to update lock file", { pid: 12345, error: 'Disk full' })
+
+    assert_raises(IOError) do
+      @launcher.send(:update_lock_file, mock_file, 12345)
+    end
   end
 end

--- a/application/test/services/command/command_client_test.rb
+++ b/application/test/services/command/command_client_test.rb
@@ -66,7 +66,7 @@ class Command::CommandClientTest < ActiveSupport::TestCase
     result = client.request(request)
 
     assert_equal 521, result.status
-    assert_equal 'Socket file not found', result.body.message
+    assert_equal 'Socket file not found. Server not running', result.body.message
   end
 
   test 'Should raise CommandError if error processing the response' do

--- a/config/.env
+++ b/config/.env
@@ -1,2 +1,3 @@
+OOD_LOOP_DETACHED_PROCESS_FILE=/tmp/detached.process.lock
 OOD_LOOP_COMMAND_SERVER_FILE=/tmp/command.server.sock
 OOD_LOOP_ZENODO_ENABLED=true


### PR DESCRIPTION
## Description
Improvements to fix edge case where 2 detached process are started when multiple simultaneous requests to the status controller.

Making parallel status requests:
`seq 20 | xargs -n1 -P10 curl -sk   -H "Authorization: Basic b29kOm9vZA=="  "https://localhost:33000/pun/sys/loop/detached_process/status"`

### Testing:

- Ensure no downloads are active.
- Schedule a couple of downloads
- trigger the script to make 10 requests to the status page.
- Look at the logs and make sure that there are more than one status request at the same second as the one that starts the detached process.
- Ensure only one process is running.


## Related Issue
Fixes #420 

## Testing
- [x] Added/updated tests
- [x] All tests pass locally
- [x] Tested manually (describe how)

## Documentation
- [ ] Updated relevant documentation
- [x] No documentation changes needed