### PR TITLE
fix: Fixed retry check for Download files

### DIFF
--- a/application/app/helpers/status_helper.rb
+++ b/application/app/helpers/status_helper.rb
@@ -10,6 +10,6 @@ module StatusHelper
   end
 
   def retry_button_visible?(file)
-    file.restart_possible?
+    FileStatus.retryable_statuses.include?(file.status)
   end
 end

--- a/application/app/models/download_file.rb
+++ b/application/app/models/download_file.rb
@@ -67,10 +67,6 @@ class DownloadFile < ApplicationDiskRecord
     ConnectorClassDispatcher.download_connector_metadata(self)
   end
 
-  def restart_possible?
-    FileStatus.retryable_statuses.include?(status) && connector_metadata.partial_downloads != false
-  end
-
   def max_file_size
     Configuration.max_download_file_size
   end

--- a/application/test/helpers/status_helper_test.rb
+++ b/application/test/helpers/status_helper_test.rb
@@ -16,27 +16,29 @@ class StatusHelperTest < ActionView::TestCase
     end
   end
 
-  test 'retry_button_visible? is true when restart is possible' do
+  test 'retry_button_visible? is true when file status does allow retry' do
     project = create_project
     file = create_download_file(project)
     file.status = FileStatus::CANCELLED
-    file.metadata = { partial_downloads: true }
     assert retry_button_visible?(file)
 
     file.status = FileStatus::ERROR
-    file.metadata = { partial_downloads: nil }
+    assert retry_button_visible?(file)
+
+    file.status = FileStatus::CANCELLED
     assert retry_button_visible?(file)
   end
 
-  test 'retry_button_visible? is false when status does not allow retry or partial downloads disabled' do
+  test 'retry_button_visible? is false when file status does not allow retry' do
     project = create_project
     file = create_download_file(project)
     file.status = FileStatus::SUCCESS
-    file.metadata = { partial_downloads: true }
     refute retry_button_visible?(file)
 
-    file.status = FileStatus::CANCELLED
-    file.metadata = { partial_downloads: false }
+    file.status = FileStatus::DOWNLOADING
+    refute retry_button_visible?(file)
+
+    file.status = FileStatus::UPLOADING
     refute retry_button_visible?(file)
   end
 end


### PR DESCRIPTION
## Description
PR to fix the logic to determine if the download file can be re-tried.

## Testing
- [x] Added/updated tests
- [x] All tests pass locally
- [x] Tested manually (describe how)

## Documentation
- [ ] Updated relevant documentation
- [x] No documentation changes needed