### PR TITLE
fix: Fixed missing scheme and port from explore forms + version default values

### DIFF
--- a/application/app/connectors/zenodo/display_repo_controller_resolver.rb
+++ b/application/app/connectors/zenodo/display_repo_controller_resolver.rb
@@ -19,7 +19,7 @@ module Zenodo
         object_type = 'depositions'
         object_id = zenodo_url.deposition_id
       else
-        server_domain =  Zenodo::ZenodoUrl::DEFAULT_SERVER
+        server_domain =  zenodo_url.domain
         object_type = 'landing'
         object_id = ':root'
         if zenodo_url&.unknown?

--- a/application/app/services/dataverse/search_dataset_files_url_builder.rb
+++ b/application/app/services/dataverse/search_dataset_files_url_builder.rb
@@ -4,7 +4,7 @@ module Dataverse
 
     def initialize(persistent_id:, version: ':latest-published', page: 1, per_page: nil, query: nil)
       @persistent_id = persistent_id
-      @version = version
+      @version = version.to_s.strip.empty? ? ':latest-published' : version
       @page = page
       @per_page = per_page || Configuration.default_pagination_items
       @query = query

--- a/application/app/services/repo/repo_resolver_service.rb
+++ b/application/app/services/repo/repo_resolver_service.rb
@@ -20,7 +20,7 @@ module Repo
     end
 
     def resolve(object_url)
-      context = RepoResolverContext.new(object_url)
+      context = Repo::RepoResolverContext.new(object_url)
       return context.result if object_url.blank?
 
       @resolvers.each do |resolver|

--- a/application/app/views/connectors/dataverse/collections/_search_bar.html.erb
+++ b/application/app/views/connectors/dataverse/collections/_search_bar.html.erb
@@ -1,5 +1,7 @@
 <div class="mb-3">
   <%= form_with url: link_to_explore(ConnectorType::DATAVERSE, repo_url, type: 'collections', id: collection.data.alias), method: :get, local: true do |f| %>
+    <%= hidden_field_tag :server_scheme, repo_url.scheme_override %>
+    <%= hidden_field_tag :server_port, repo_url.port_override %>
     <div class="input-group">
       <%= f.text_field :query, value: params[:query], class: 'form-control', placeholder: t('.field_search_placeholder') %>
       <%= f.submit t('.button_submit_text'), class: 'btn btn-primary' %>

--- a/application/app/views/connectors/dataverse/datasets/_dataset_files.html.erb
+++ b/application/app/views/connectors/dataverse/datasets/_dataset_files.html.erb
@@ -14,6 +14,8 @@
       <%= hidden_field_tag 'version', dataset.version %>
       <%= hidden_field_tag 'page', files_page.page %>
       <%= hidden_field_tag 'query', files_page.query %>
+      <%= hidden_field_tag :server_scheme, repo_url.scheme_override %>
+      <%= hidden_field_tag :server_port, repo_url.port_override %>
       <div class="row">
         <h2 id="search-results-heading" class="visually-hidden"><%= t('connectors.dataverse.datasets.dataset_files.header_dataset_files_a11y_text') %></h2>
         <table class="table table-bordered table-hover align-middle">

--- a/application/app/views/connectors/dataverse/datasets/_search_bar.html.erb
+++ b/application/app/views/connectors/dataverse/datasets/_search_bar.html.erb
@@ -1,6 +1,8 @@
 <div class="mb-3">
   <%= form_with url: link_to_explore(ConnectorType::DATAVERSE, repo_url, type: 'datasets', id: persistent_id), id: 'dataset-search-form', method: :get, local: true do |f| %>
     <%= hidden_field_tag :version, version %>
+    <%= hidden_field_tag :server_scheme, repo_url.scheme_override %>
+    <%= hidden_field_tag :server_port, repo_url.port_override %>
     <div class="input-group">
       <%= f.text_field :query, value: params[:query], class: 'form-control', placeholder: t('.field_search_placeholder') %>
       <%= f.submit t('.button_submit_text'), class: 'btn btn-primary' %>

--- a/application/app/views/connectors/zenodo/landing/index.html.erb
+++ b/application/app/views/connectors/zenodo/landing/index.html.erb
@@ -9,6 +9,8 @@
   </div>
 
   <%= form_with url: link_to_explore(ConnectorType::ZENODO, repo_url, type: 'landing', id: ':root'), method: :get, local: true do |f| %>
+    <%= hidden_field_tag :server_scheme, repo_url.scheme_override %>
+    <%= hidden_field_tag :server_port, repo_url.port_override %>
     <div class="input-group mb-3">
       <%= f.text_field :query, class: 'form-control', value: query, placeholder: t('zenodo.landing_page.index.field_search_placeholder') %>
       <%= f.submit t('zenodo.landing_page.index.button_submit_text'), class: 'btn btn-primary' %>

--- a/application/app/views/connectors/zenodo/shared/_zenodo_view_files.html.erb
+++ b/application/app/views/connectors/zenodo/shared/_zenodo_view_files.html.erb
@@ -6,6 +6,8 @@
   <% if dataset.files.any? %>
     <%= form_with url: post_url, id: 'dataset-download-files-form', method: :post, local: true, class: "p-3 rounded bg-light", data: {controller: "select-files"} do %>
       <%= hidden_field_tag :id, dataset_id %>
+      <%= hidden_field_tag :server_scheme, repo_url.scheme_override %>
+      <%= hidden_field_tag :server_port, repo_url.port_override %>
       <div class="row">
         <h2 id="dataset-files-heading" class="visually-hidden"><%= t('.header_dataset_files_a11y_text') %></h2>
         <table class="table table-bordered table-hover align-middle">

--- a/application/test/services/dataverse/dataset_service_test.rb
+++ b/application/test/services/dataverse/dataset_service_test.rb
@@ -3,12 +3,9 @@ require 'test_helper'
 class Dataverse::DatasetServiceTest < ActiveSupport::TestCase
   include DataverseHelper
 
-  def setup
-    @client = HttpClientMock.new(file_path: fixture_path('dataverse/create_dataset_response/valid_response.json'))
-    @service = Dataverse::DatasetService.new('https://example.com', http_client: @client, api_key: 'KEY')
-  end
-
   test 'create_dataset posts data and returns response object' do
+    client = HttpClientMock.new(file_path: fixture_path('dataverse/create_dataset_response/valid_response.json'))
+    target = Dataverse::DatasetService.new('https://example.com', http_client: client, api_key: 'KEY')
     dataset = Dataverse::CreateDatasetRequest.new(
       title: 't',
       description: 'd',
@@ -16,50 +13,92 @@ class Dataverse::DatasetServiceTest < ActiveSupport::TestCase
       contact_email: 'e@example.com',
       subjects: ['Other']
     )
-    res = @service.create_dataset('dv1', dataset)
+    res = target.create_dataset('dv1', dataset)
     assert_kind_of Dataverse::CreateDatasetResponse, res
     assert_equal 'OK', res.status
   end
 
   test 'find_dataset_version_by_persistent_id raises unauthorized' do
-    unauthorized_client = HttpClientMock.new(file_path: fixture_path('dataverse/dataset_version_response/valid_response.json'), status_code: 401)
-    service = Dataverse::DatasetService.new('https://example.com', http_client: unauthorized_client)
+    client = HttpClientMock.new(file_path: fixture_path('dataverse/dataset_version_response/valid_response.json'), status_code: 401)
+    target = Dataverse::DatasetService.new('https://example.com', http_client: client)
     assert_raises(Dataverse::DatasetService::UnauthorizedException) do
-      service.find_dataset_version_by_persistent_id('doi:1')
+      target.find_dataset_version_by_persistent_id('doi:1')
     end
   end
 
   test 'search_dataset_files_by_persistent_id parses list' do
-    @client = HttpClientMock.new(file_path: fixture_path('dataverse/dataset_files_response/valid_response.json'))
-    @service = Dataverse::DatasetService.new('https://example.com', http_client: @client)
-    res = @service.search_dataset_files_by_persistent_id('doi:1', page: 1, per_page: 2)
+    client = HttpClientMock.new(file_path: fixture_path('dataverse/dataset_files_response/valid_response.json'))
+    target = Dataverse::DatasetService.new('https://example.com', http_client: client)
+    res = target.search_dataset_files_by_persistent_id('doi:1', page: 1, per_page: 2)
     assert_kind_of Dataverse::DatasetFilesResponse, res
     assert_equal 2, res.files.size
   end
 
   test 'search_dataset_files_by_persistent_id uses version in url' do
-    @client = HttpClientMock.new(file_path: fixture_path('dataverse/dataset_files_response/valid_response.json'))
-    @service = Dataverse::DatasetService.new('https://example.com', http_client: @client)
-    @service.search_dataset_files_by_persistent_id('doi:1', version: '2.0')
-    assert_includes @client.called_path, '/versions/2.0/files'
+    client = HttpClientMock.new(file_path: fixture_path('dataverse/dataset_files_response/valid_response.json'))
+    target = Dataverse::DatasetService.new('https://example.com', http_client: client)
+    target.search_dataset_files_by_persistent_id('doi:1', version: '2.0')
+    assert_includes client.called_path, '/versions/2.0/files'
   end
 
   test 'find_dataset_version_by_persistent_id uses version in url' do
-    @client = HttpClientMock.new(file_path: fixture_path('dataverse/dataset_version_response/valid_response.json'))
-    @service = Dataverse::DatasetService.new('https://example.com', http_client: @client)
-    @service.find_dataset_version_by_persistent_id('doi:1', version: '2.0')
-    assert_includes @client.called_path, '/versions/2.0'
+    client = HttpClientMock.new(file_path: fixture_path('dataverse/dataset_version_response/valid_response.json'))
+    target = Dataverse::DatasetService.new('https://example.com', http_client: client)
+    target.find_dataset_version_by_persistent_id('doi:1', version: '2.0')
+    assert_includes client.called_path, '/versions/2.0'
   end
 
   test 'dataset_versions_by_persistent_id parses response and requires key' do
-    @client = HttpClientMock.new(file_path: fixture_path('dataverse/dataset_versions_response/valid_response.json'))
-    service = Dataverse::DatasetService.new('https://example.com', http_client: @client, api_key: 'KEY')
-    res = service.dataset_versions_by_persistent_id('doi:1')
+    client = HttpClientMock.new(file_path: fixture_path('dataverse/dataset_versions_response/valid_response.json'))
+    target = Dataverse::DatasetService.new('https://example.com', http_client: client, api_key: 'KEY')
+    res = target.dataset_versions_by_persistent_id('doi:1')
     assert_instance_of Dataverse::DatasetVersionsResponse, res
     assert_equal 2, res.versions.size
     assert_equal 'doi:10.70122/FK2/O9JYAO', res.versions.first.persistent_id
     assert_equal ':draft', res.versions.first.version
-    assert_includes @client.called_path, 'excludeMetadataBlocks=true'
+    assert_includes client.called_path, 'excludeMetadataBlocks=true'
+  end
+
+  test 'find_dataset_version_by_persistent_id uses default version for nil' do
+    client = HttpClientMock.new(file_path: fixture_path('dataverse/dataset_version_response/valid_response.json'))
+    target = Dataverse::DatasetService.new('https://example.com', http_client: client, api_key: 'KEY')
+    target.find_dataset_version_by_persistent_id('doi:1', version: nil)
+    assert_includes client.called_path, '/versions/:latest-published'
+  end
+
+  test 'find_dataset_version_by_persistent_id uses default version for empty string' do
+    client = HttpClientMock.new(file_path: fixture_path('dataverse/dataset_version_response/valid_response.json'))
+    target = Dataverse::DatasetService.new('https://example.com', http_client: client, api_key: 'KEY')
+    target.find_dataset_version_by_persistent_id('doi:1', version: '')
+    assert_includes client.called_path, '/versions/:latest-published'
+  end
+
+  test 'find_dataset_version_by_persistent_id uses default version for whitespace' do
+    client = HttpClientMock.new(file_path: fixture_path('dataverse/dataset_version_response/valid_response.json'))
+    target = Dataverse::DatasetService.new('https://example.com', http_client: client, api_key: 'KEY')
+    target.find_dataset_version_by_persistent_id('doi:1', version: '  ')
+    assert_includes client.called_path, '/versions/:latest-published'
+  end
+
+  test 'search_dataset_files_by_persistent_id uses default version for nil' do
+    client = HttpClientMock.new(file_path: fixture_path('dataverse/dataset_files_response/valid_response.json'))
+    target = Dataverse::DatasetService.new('https://example.com', http_client: client, api_key: 'KEY')
+    target.search_dataset_files_by_persistent_id('doi:1', version: nil)
+    assert_includes client.called_path, '/versions/:latest-published/files'
+  end
+
+  test 'search_dataset_files_by_persistent_id uses default version for empty string' do
+    client = HttpClientMock.new(file_path: fixture_path('dataverse/dataset_files_response/valid_response.json'))
+    target = Dataverse::DatasetService.new('https://example.com', http_client: client, api_key: 'KEY')
+    target.search_dataset_files_by_persistent_id('doi:1', version: '')
+    assert_includes client.called_path, '/versions/:latest-published/files'
+  end
+
+  test 'search_dataset_files_by_persistent_id uses default version for whitespace' do
+    client = HttpClientMock.new(file_path: fixture_path('dataverse/dataset_files_response/valid_response.json'))
+    target = Dataverse::DatasetService.new('https://example.com', http_client: client, api_key: 'KEY')
+    target.search_dataset_files_by_persistent_id('doi:1', version: '  ')
+    assert_includes client.called_path, '/versions/:latest-published/files'
   end
 
 end

--- a/application/test/services/dataverse/search_dataset_files_url_builder_test.rb
+++ b/application/test/services/dataverse/search_dataset_files_url_builder_test.rb
@@ -61,5 +61,23 @@ module Dataverse
         SearchDatasetFilesUrlBuilder.new(persistent_id: nil).build
       end
     end
+
+    def test_uses_default_version_for_nil
+      builder = SearchDatasetFilesUrlBuilder.new(persistent_id: 'doi:10.5072/FK2/ABC123', version: nil)
+      url = builder.build
+      assert_includes url, '/versions/:latest-published/files'
+    end
+
+    def test_uses_default_version_for_empty_string
+      builder = SearchDatasetFilesUrlBuilder.new(persistent_id: 'doi:10.5072/FK2/ABC123', version: '')
+      url = builder.build
+      assert_includes url, '/versions/:latest-published/files'
+    end
+
+    def test_uses_default_version_for_whitespace
+      builder = SearchDatasetFilesUrlBuilder.new(persistent_id: 'doi:10.5072/FK2/ABC123', version: '  ')
+      url = builder.build
+      assert_includes url, '/versions/:latest-published/files'
+    end
   end
 end

--- a/application/test/views/zenodo/view_files_view_test.rb
+++ b/application/test/views/zenodo/view_files_view_test.rb
@@ -7,17 +7,21 @@ class ZenodoViewFilesViewTest < ActionView::TestCase
     file = Struct.new(:id, :filename, :filesize).new('1', 'file1.txt', 1024)
     dataset = Struct.new(:files).new([file])
 
+    repo_url = Struct.new(:scheme_override, :port_override).new('https', '443')
     html = render partial: 'connectors/zenodo/shared/zenodo_view_files',
-                   locals: { post_url: '/post', dataset: dataset, dataset_id: '1', repo_url: nil }
+                   locals: { post_url: '/post', dataset: dataset, dataset_id: '1', repo_url: repo_url }
 
     assert_includes html, 'file1.txt'
+    assert_includes html, 'name="server_scheme"'
+    assert_includes html, 'name="server_port"'
   end
 
   test 'renders empty message when dataset has no files' do
     dataset = Struct.new(:files).new([])
 
+    repo_url = Struct.new(:scheme_override, :port_override).new('https', '443')
     html = render partial: 'connectors/zenodo/shared/zenodo_view_files',
-                   locals: { post_url: '/post', dataset: dataset, dataset_id: '1', repo_url: nil }
+                   locals: { post_url: '/post', dataset: dataset, dataset_id: '1', repo_url: repo_url }
 
     assert_includes html, I18n.t('connectors.zenodo.shared.zenodo_view_files.msg_empty_dataset_text')
   end


### PR DESCRIPTION
## Description
Fixes for bugs found while testing a new feature.
After this is merge, will create a new release and use it for the next deployment.

The first bug is in the new explore Dataverse and Zenodo forms.
The URL scheme and port for the explore forms are on the URL and Rails requires them to be in form fields.
These parameters are removed by Rails.

The second bug relates to how we process the version parameter.
If version is empty string, the code will not used the default value and the generated URLs are broken, causing API errors.

## Testing
- [ ] Added/updated tests
- [ ] All tests pass locally
- [ ] Tested manually (describe how)

## Documentation
- [ ] Updated relevant documentation
- [ ] No documentation changes needed