### PR TITLE
fix: Fixed Zenodo upload URL creation

### DIFF
--- a/application/app/lib/fluent_url.rb
+++ b/application/app/lib/fluent_url.rb
@@ -11,7 +11,7 @@ class FluentUrl
   def add_path(part)
     return self if part.blank?
 
-    @segments << part
+    @segments << Addressable::URI.encode_component(part, Addressable::URI::CharacterClasses::PATH)
     self
   end
 

--- a/application/app/models/upload_status.rb
+++ b/application/app/models/upload_status.rb
@@ -14,7 +14,11 @@ class UploadStatus
     command_client = Command::CommandClient.new(socket_path: ::Configuration.command_server_socket_file)
     request = Command::Request.new(command: 'upload.status', body: { project_id: file.project_id, upload_bundle_id: file.upload_bundle_id, file_id: file.id })
     response = command_client.request(request)
+    return 0 if response.error? || response.body.status.nil?
+
     total = response.body.status[:total].to_i
+    return 0 if total.zero?
+
     uploaded = response.body.status[:uploaded].to_i
     [(uploaded.to_f / total * 100).to_i, 100].min
   end

--- a/application/app/services/command/response.rb
+++ b/application/app/services/command/response.rb
@@ -5,9 +5,17 @@ module Command
     attr_reader :status, :headers, :body
 
     def initialize(status: 200, headers: {}, body: {})
-      @status = status
+      @status = status.to_i
       @headers = headers || {}
       @body = OpenStruct.new(body)
+    end
+
+    def success?
+      status == 200
+    end
+
+    def error?
+      !success?
     end
 
     def to_h

--- a/application/test/lib/fluent_url_test.rb
+++ b/application/test/lib/fluent_url_test.rb
@@ -93,4 +93,41 @@ class FluentUrlTest < ActiveSupport::TestCase
                    .add_path('xyz')
     assert_equal 'https://example.com/files/abc/xyz', url.to_s
   end
+
+  test 'add_path should support deep paths' do
+    url = FluentUrl.new('https://example.com/api/v1/')
+                   .add_path('/projects/123/xyz')
+    assert_equal 'https://example.com/api/v1/projects/123/xyz', url.to_s
+  end
+
+  test 'add_path should encode spaces in path segments' do
+    url = FluentUrl.new('https://example.com')
+                   .add_path('my file name.txt')
+    assert_equal 'https://example.com/my%20file%20name.txt', url.to_s
+
+    url = FluentUrl.new('https://example.com')
+                   .add_path('/projects/123/my file name.txt')
+    assert_equal 'https://example.com/projects/123/my%20file%20name.txt', url.to_s
+  end
+
+  test 'add_path should encode special characters in path segments' do
+    url = FluentUrl.new('https://example.com')
+                   .add_path('/projects/file&name')
+                   .add_path('/dataset/data+set')
+    assert_equal 'https://example.com/projects/file&name/dataset/data+set', url.to_s
+  end
+
+  test 'add_path should encode unicode characters in path segments' do
+    url = FluentUrl.new('https://example.com')
+                   .add_path('résumé.pdf')
+    assert_equal 'https://example.com/r%C3%A9sum%C3%A9.pdf', url.to_s
+  end
+
+  test 'add_path should handle mixed encoded and unencoded segments' do
+    url = FluentUrl.new('https://example.com')
+                   .add_path('api')
+                   .add_path('files with spaces')
+                   .add_path('normal')
+    assert_equal 'https://example.com/api/files%20with%20spaces/normal', url.to_s
+  end
 end

--- a/application/test/models/upload_status_test.rb
+++ b/application/test/models/upload_status_test.rb
@@ -25,4 +25,56 @@ class UploadStatusTest < ActiveSupport::TestCase
     @file.status = FileStatus::SUCCESS
     assert_equal 100, @status.upload_progress
   end
+
+  test 'error file returns 100' do
+    @file.status = FileStatus::ERROR
+    assert_equal 100, @status.upload_progress
+  end
+
+  test 'cancelled file returns 100' do
+    @file.status = FileStatus::CANCELLED
+    assert_equal 100, @status.upload_progress
+  end
+
+  test 'returns 0 when command client response has error' do
+    mock_client = mock('client')
+    mock_response = mock('response')
+    mock_response.stubs(:error?).returns(true)
+    mock_client.expects(:request).returns(mock_response)
+    Command::CommandClient.expects(:new).returns(mock_client)
+    @file.status = FileStatus::UPLOADING
+    assert_equal 0, @status.upload_progress
+  end
+
+  test 'returns 0 when command client response body status is nil' do
+    mock_client = mock('client')
+    mock_client.expects(:request).returns(OpenStruct.new(error?: false, body: OpenStruct.new(status: nil)))
+    Command::CommandClient.expects(:new).returns(mock_client)
+    @file.status = FileStatus::UPLOADING
+    assert_equal 0, @status.upload_progress
+  end
+
+  test 'calculates progress correctly from command response' do
+    mock_client = mock('client')
+    mock_client.expects(:request).returns(OpenStruct.new(error?: false, body: OpenStruct.new(status: {total: 200, uploaded: 75})))
+    Command::CommandClient.expects(:new).returns(mock_client)
+    @file.status = FileStatus::UPLOADING
+    assert_equal 37, @status.upload_progress
+  end
+
+  test 'caps progress at 100 percent' do
+    mock_client = mock('client')
+    mock_client.expects(:request).returns(OpenStruct.new(error?: false, body: OpenStruct.new(status: {total: 100, uploaded: 150})))
+    Command::CommandClient.expects(:new).returns(mock_client)
+    @file.status = FileStatus::UPLOADING
+    assert_equal 100, @status.upload_progress
+  end
+
+  test 'handles zero total gracefully' do
+    mock_client = mock('client')
+    mock_client.expects(:request).returns(OpenStruct.new(error?: false, body: OpenStruct.new(status: {total: 0, uploaded: 0})))
+    Command::CommandClient.expects(:new).returns(mock_client)
+    @file.status = FileStatus::UPLOADING
+    assert_equal 0, @status.upload_progress
+  end
 end

--- a/application/test/services/command/response_test.rb
+++ b/application/test/services/command/response_test.rb
@@ -1,0 +1,117 @@
+require 'test_helper'
+
+class Command::ResponseTest < ActiveSupport::TestCase
+  test 'initialize with default values' do
+    response = Command::Response.new
+    assert_equal 200, response.status
+    assert_equal({}, response.headers)
+    assert_kind_of OpenStruct, response.body
+  end
+
+  test 'initialize with custom values' do
+    response = Command::Response.new(
+      status: 404,
+      headers: { 'Content-Type' => 'application/json' },
+      body: { message: 'Not found' }
+    )
+    assert_equal 404, response.status
+    assert_equal({ 'Content-Type' => 'application/json' }, response.headers)
+    assert_equal 'Not found', response.body.message
+  end
+
+  test 'initialize converts string status to integer' do
+    response = Command::Response.new(status: '500')
+    assert_equal 500, response.status
+    assert_kind_of Integer, response.status
+  end
+
+  test 'success? returns true for 200 status' do
+    response = Command::Response.new(status: 200)
+    assert response.success?
+  end
+
+  test 'success? returns false for non-200 status' do
+    response = Command::Response.new(status: 404)
+    refute response.success?
+  end
+
+  test 'error? returns false for 200 status' do
+    response = Command::Response.new(status: 200)
+    refute response.error?
+  end
+
+  test 'error? returns true for non-200 status' do
+    response = Command::Response.new(status: 500)
+    assert response.error?
+  end
+
+  test 'to_h returns hash representation' do
+    response = Command::Response.new(
+      status: 201,
+      headers: { 'Location' => '/api/resource/1' },
+      body: { id: 1, name: 'test' }
+    )
+    expected = {
+      status: 201,
+      headers: { 'Location' => '/api/resource/1' },
+      body: { id: 1, name: 'test' }
+    }
+    assert_equal expected, response.to_h
+  end
+
+  test 'to_json returns json string' do
+    response = Command::Response.new(body: { message: 'success' })
+    json_string = response.to_json
+    parsed = JSON.parse(json_string)
+    assert_equal 200, parsed['status']
+    assert_equal 'success', parsed['body']['message']
+  end
+
+  test 'from_json creates response from json string' do
+    json = '{"status":201,"headers":{"Content-Type":"application/json"},"body":{"id":1}}'
+    response = Command::Response.from_json(json)
+    assert_equal 201, response.status
+    assert_equal 'application/json', response.headers['Content-Type'.to_sym]
+    assert_equal 1, response.body.id
+  end
+
+  test 'error creates error response' do
+    response = Command::Response.error(status: 400, message: 'Bad request')
+    assert_equal 400, response.status
+    assert_equal 'Bad request', response.body.message
+    assert response.error?
+  end
+
+  test 'error creates error response with handler' do
+    handler = Object.new
+    response = Command::Response.error(status: 500, message: 'Internal error', handler: handler)
+    assert_equal 500, response.status
+    assert_equal 'Internal error', response.body.message
+    assert_equal 'Object', response.headers[:handler]
+  end
+
+  test 'ok creates success response' do
+    response = Command::Response.ok(body: { result: 'success' })
+    assert_equal 200, response.status
+    assert_equal 'success', response.body.result
+    assert response.success?
+  end
+
+  test 'ok creates success response with handler' do
+    handler = Object.new
+    response = Command::Response.ok(body: { data: 'test' }, handler: handler)
+    assert_equal 200, response.status
+    assert_equal 'test', response.body.data
+    assert_equal 'Object', response.headers[:handler]
+  end
+
+  test 'handles nil headers gracefully' do
+    response = Command::Response.new(headers: nil)
+    assert_equal({}, response.headers)
+  end
+
+  test 'handles nil body gracefully' do
+    response = Command::Response.new(body: nil)
+    assert_kind_of OpenStruct, response.body
+  end
+end


### PR DESCRIPTION
## Description
Uploading files with spaces in the filename are causing errors when uploading to Zenodo.
This is because the Zenodo upload URL contains the filename in the URL. Our logic to create the URL was not encoding the path parameters.

## Testing
- [ ] Added/updated tests
- [ ] All tests pass locally
- [ ] Tested manually (describe how)

## Documentation
- [ ] Updated relevant documentation
- [ ] No documentation changes needed