### PR TITLE
Fix: project create event bug

### DIFF
--- a/application/app/connectors/dataverse/handlers/datasets.rb
+++ b/application/app/connectors/dataverse/handlers/datasets.rb
@@ -1,6 +1,7 @@
 module Dataverse::Handlers
   class Datasets
     include LoggingCommon
+    include EventLogger
 
     def initialize(object_id = nil)
       @persistent_id = object_id
@@ -125,7 +126,9 @@ module Dataverse::Handlers
           errors = project.errors.full_messages.join(', ')
           return ConnectorResult.new(message: { alert: I18n.t('connectors.dataverse.datasets.download.error_generating_project', errors: errors) }, success: false)
         end
+        log_project_event(project, message: 'events.project.created', metadata: { name: project.name, folder: project.download_dir })
         Current.settings.update_user_settings({ active_project: project.id.to_s })
+        log_project_event(project, message: 'events.project.active', metadata: { name: project.name })
       end
 
       download_files = project_service.initialize_download_files(project, @persistent_id, dataset, files_page, file_ids)

--- a/application/app/connectors/zenodo/handlers/records.rb
+++ b/application/app/connectors/zenodo/handlers/records.rb
@@ -1,6 +1,7 @@
 module Zenodo::Handlers
   class Records
     include LoggingCommon
+    include EventLogger
 
     def initialize(object_id = nil)
       @record_id = object_id
@@ -70,7 +71,9 @@ module Zenodo::Handlers
           errors = project.errors.full_messages.join(', ')
           return ConnectorResult.new(message: { alert: I18n.t('zenodo.records.message_project_error', errors: errors) }, success: false)
         end
+        log_project_event(project, message: 'events.project.created', metadata: { name: project.name, folder: project.download_dir })
         Current.settings.update_user_settings({ active_project: project.id.to_s })
+        log_project_event(project, message: 'events.project.active', metadata: { name: project.name })
       end
 
       download_files = project_service.create_files_from_record(project, record, file_ids)

--- a/application/test/connectors/dataverse/handlers/datasets_test.rb
+++ b/application/test/connectors/dataverse/handlers/datasets_test.rb
@@ -80,6 +80,7 @@ class Dataverse::Handlers::DatasetsTest < ActiveSupport::TestCase
     project.expects(:save).returns(true)
     project.stubs(:name).returns('Proj')
     project.stubs(:id).returns('1')
+    project.stubs(:download_dir).returns('/tmp')
 
     file = mock('file')
     file.stubs(:valid?).returns(true)
@@ -91,6 +92,8 @@ class Dataverse::Handlers::DatasetsTest < ActiveSupport::TestCase
     Dataverse::ProjectService.expects(:new).with('https://dataverse.org').returns(proj_service)
 
     @settings.expects(:update_user_settings).with({ active_project: '1' })
+    @explorer.expects(:log_project_event).with(project, message: 'events.project.created', metadata: { name: project.name, folder: project.download_dir })
+    @explorer.expects(:log_project_event).with(project, message: 'events.project.active', metadata: { name: project.name })
     res = @explorer.create(repo_url: @repo_url, file_ids: ['f1'], project_id: '1')
     assert res.success?
   end

--- a/application/test/connectors/zenodo/handlers/records_test.rb
+++ b/application/test/connectors/zenodo/handlers/records_test.rb
@@ -53,6 +53,7 @@ class Zenodo::Handlers::RecordsTest < ActiveSupport::TestCase
     project.expects(:save).returns(true)
     project.stubs(:name).returns('Proj')
     project.stubs(:id).returns(1)
+    project.stubs(:download_dir).returns('/tmp')
 
     file = mock('file')
     file.stubs(:valid?).returns(true)
@@ -64,6 +65,8 @@ class Zenodo::Handlers::RecordsTest < ActiveSupport::TestCase
     Zenodo::ProjectService.expects(:new).with(zenodo_url: 'https://zenodo.org').returns(proj_service)
 
     @settings.expects(:update_user_settings).with({ active_project: project.id.to_s })
+    @explorer.expects(:log_project_event).with(project, message: 'events.project.created', metadata: { name: project.name, folder: project.download_dir })
+    @explorer.expects(:log_project_event).with(project, message: 'events.project.active', metadata: { name: project.name })
     res = @explorer.create(repo_url: @repo_url, file_ids: ['f1'], project_id: '1')
     assert res.success?
   end


### PR DESCRIPTION
## Description
Create the project events when the project is created automatically when there are no projects on a download

## Related Issue
Fixes https://github.com/IQSS/ondemand-loop/issues/469

## Changes Made
- create the events
- update the tests

## Testing
- [x] Added/updated tests
- [x] All tests pass locally
- [x] Tested manually (describe how)

## Documentation
- [ ] Updated relevant documentation
- [ ] No documentation changes needed