### PR TITLE
feat: Added support to run OnDemand Loop without local configuration

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
-all:: loop_up
-.PHONY: loop_up loop_down loop_build remote_dev_build release_build loop_docker_builder clean logs bash test test_bash test_exec version release_notes coverage guide guide_dev
+all:: local_up
+.PHONY: loop_up loop_down local_up local_down loop_build remote_dev_build release_build loop_docker_builder clean logs bash test test_bash test_exec version release_notes coverage guide guide_dev
 
 # OOD Configuration
 include tools/make/ood_versions.mk
@@ -15,6 +15,12 @@ loop_up: loop_down
 
 loop_down:
 	$(ENV) $(COMPOSE_CMD) -p loop_passenger down -v || :
+
+local_up: local_down
+	$(ENV) $(COMPOSE_CMD) -f docker-compose.yml -f docker/docker-local-override.yaml -p loop_passenger up --build || :
+
+local_down:
+	$(ENV) $(COMPOSE_CMD) -f docker-compose.yml -f docker/docker-local-override.yaml -p loop_passenger down -v || :
 
 loop_build:
 	docker run --platform=linux/amd64 --rm -v $(WORKING_DIR)/application:/usr/local/app -v $(WORKING_DIR)/scripts:/usr/local/scripts -w /usr/local/app $(LOOP_BUILDER_IMAGE) /usr/local/scripts/loop_build.sh

--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
-all:: local_up
-.PHONY: loop_up loop_down local_up local_down loop_build remote_dev_build release_build loop_docker_builder clean logs bash test test_bash test_exec version release_notes coverage guide guide_dev
+all:: dev_up
+.PHONY: loop_up loop_down dev_up dev_down loop_build remote_dev_build release_build loop_docker_builder clean logs bash test test_bash test_exec version release_notes coverage guide guide_dev
 
 # OOD Configuration
 include tools/make/ood_versions.mk
@@ -16,10 +16,10 @@ loop_up: loop_down
 loop_down:
 	$(ENV) $(COMPOSE_CMD) -p loop_passenger down -v || :
 
-local_up: local_down
+dev_up: dev_down
 	$(ENV) $(COMPOSE_CMD) -f docker-compose.yml -f docker/docker-local-override.yaml -p loop_passenger up --build || :
 
-local_down:
+dev_down:
 	$(ENV) $(COMPOSE_CMD) -f docker-compose.yml -f docker/docker-local-override.yaml -p loop_passenger down -v || :
 
 loop_build:

--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ follow the steps below or refer to the [Quick Start section of the Development G
 
 ```sh
 make loop_build
-make loop_up
+make dev_up
 ```
 
 Once the containers are running, navigate to the application URL and log in with the local test credentials:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -23,12 +23,7 @@ services:
     cgroup: host
     volumes:
       - /sys/fs/cgroup:/sys/fs/cgroup:rw
-      - ./data/ood:/home/ood/ondemand/data
-      - ./data/metadata:/home/ood/.loop_metadata
-      - ./data/downloads:/home/ood/loop_downloads
       - ./application:/var/www/ood/apps/sys/loop
-      - ./config/.env:/var/www/ood/apps/sys/loop/.env
-      - ./config/loop.d:/etc/loop/config/loop.d
       - ./docker/loop.conf:/var/lib/ondemand-nginx/config/apps/sys/loop.conf
     ports:
       - "33000:443"

--- a/docker/docker-local-override.yaml
+++ b/docker/docker-local-override.yaml
@@ -1,0 +1,8 @@
+services:
+  ood:
+    volumes:
+      - ./data/ood:/home/ood/ondemand/data
+      - ./data/metadata:/home/ood/.loop_metadata
+      - ./data/downloads:/home/ood/loop_downloads
+      - ./config/.env:/var/www/ood/apps/sys/loop/.env
+      - ./config/loop.d:/etc/loop/config/loop.d

--- a/docs/guide/content/development_guide/contributing.md
+++ b/docs/guide/content/development_guide/contributing.md
@@ -26,7 +26,7 @@ Whether you're fixing bugs, adding features, or improving documentation, this gu
 4. **Start the development environment:**
    ```bash
    make loop_build   # Builds the application
-   make loop_up      # Starts the environment
+   make local_up     # Starts the development environment
    ```
 
 ---

--- a/docs/guide/content/development_guide/contributing.md
+++ b/docs/guide/content/development_guide/contributing.md
@@ -26,7 +26,7 @@ Whether you're fixing bugs, adding features, or improving documentation, this gu
 4. **Start the development environment:**
    ```bash
    make loop_build   # Builds the application
-   make local_up     # Starts the development environment
+   make dev_up       # Starts the development environment
    ```
 
 ---

--- a/docs/guide/content/development_guide/index.md
+++ b/docs/guide/content/development_guide/index.md
@@ -9,14 +9,14 @@ Clone the [repository](https://github.com/IQSS/ondemand-loop) and start the loca
 
 ```bash
 make loop_build
-make loop_up
+make local_up
 ```
-The make loop_up command starts the development environment using Docker Compose.
+The `make local_up` command starts the development environment using Docker Compose with local development configuration.
 It runs in the foreground, streaming logs from all containers to your terminal.
 The shell prompt will not return until you stop the environment manually.
 
 To stop the environment, press <kbd>Ctrl</kbd>+<kbd>C</kbd>. This will gracefully shut down all containers.
-Alternatively, in another terminal you can run: `make loop_down`
+Alternatively, in another terminal you can run: `make local_down`
 
 Once the containers are running visit [https://localhost:33000/pun/sys/loop](https://localhost:33000/pun/sys/loop) and log in with the test user `ood/ood`.
 

--- a/docs/guide/content/development_guide/index.md
+++ b/docs/guide/content/development_guide/index.md
@@ -9,14 +9,14 @@ Clone the [repository](https://github.com/IQSS/ondemand-loop) and start the loca
 
 ```bash
 make loop_build
-make local_up
+make dev_up
 ```
-The `make local_up` command starts the development environment using Docker Compose with local development configuration.
+The `make dev_up` command starts the development environment using Docker Compose with local development configuration.
 It runs in the foreground, streaming logs from all containers to your terminal.
 The shell prompt will not return until you stop the environment manually.
 
 To stop the environment, press <kbd>Ctrl</kbd>+<kbd>C</kbd>. This will gracefully shut down all containers.
-Alternatively, in another terminal you can run: `make local_down`
+Alternatively, in another terminal you can run: `make dev_down`
 
 Once the containers are running visit [https://localhost:33000/pun/sys/loop](https://localhost:33000/pun/sys/loop) and log in with the test user `ood/ood`.
 

--- a/docs/guide/content/development_guide/local_environment.md
+++ b/docs/guide/content/development_guide/local_environment.md
@@ -52,21 +52,21 @@ Build the application in development mode and start the containers:
 
 ```bash
 make loop_build
-make local_up
+make dev_up
 ```
 
-The `make local_up` command starts the development environment using Docker Compose with local development configuration.
+The `make dev_up` command starts the development environment using Docker Compose with local development configuration.
 It runs in the foreground, streaming logs from all containers to your terminal.
 The shell prompt will not return until you stop the environment manually.
 
 To stop the environment, press <kbd>Ctrl</kbd>+<kbd>C</kbd>. This will gracefully shut down all containers.
-Alternatively, in another terminal you can run: `make local_down`
+Alternatively, in another terminal you can run: `make dev_down`
 
 #### Development vs Vanilla Environment
 
 The project provides two different targets for running the application locally:
 
-- **`make local_up`** - **Recommended for development**. Uses additional volume mounts for local configuration and development files. This target loads both the main `docker-compose.yml` and the local override file `docker/docker-local-override.yaml`.
+- **`make dev_up`** - **Recommended for development**. Uses additional volume mounts for local configuration and development files. This target loads both the main `docker-compose.yml` and the local override file `docker/docker-local-override.yaml`.
 
 - **`make loop_up`** - **Vanilla installation**. Uses only the base Docker Compose configuration without local development overrides. Use this when you need to test the application in a configuration closer to production or for troubleshooting configuration issues.
 
@@ -88,8 +88,8 @@ You may also override `OOD_IMAGE` to use another container that already has Open
 |---------------------------|----------------------------------------------------------------------|
 | `make loop_docker_builder`| Build the Docker image used for compiling the app                    |
 | `make loop_build`         | Install dependencies and build the application under `application/`  |
-| `make local_up`           | **Start the local development environment** (recommended)            |
-| `make local_down`         | **Stop and remove the development environment containers**           |
+| `make dev_up`             | **Start the local development environment** (recommended)            |
+| `make dev_down`           | **Stop and remove the development environment containers**           |
 | `make loop_up`            | Start the vanilla environment (no local overrides)                  |
 | `make loop_down`          | Stop and remove the vanilla environment containers                   |
 | `make clean`              | Remove build artifacts and log files                                 |

--- a/docs/guide/content/development_guide/local_environment.md
+++ b/docs/guide/content/development_guide/local_environment.md
@@ -52,15 +52,23 @@ Build the application in development mode and start the containers:
 
 ```bash
 make loop_build
-make loop_up
+make local_up
 ```
 
-The `make loop_up` command starts the development environment using Docker Compose.
+The `make local_up` command starts the development environment using Docker Compose with local development configuration.
 It runs in the foreground, streaming logs from all containers to your terminal.
 The shell prompt will not return until you stop the environment manually.
 
 To stop the environment, press <kbd>Ctrl</kbd>+<kbd>C</kbd>. This will gracefully shut down all containers.
-Alternatively, in another terminal you can run: `make loop_down`
+Alternatively, in another terminal you can run: `make local_down`
+
+#### Development vs Vanilla Environment
+
+The project provides two different targets for running the application locally:
+
+- **`make local_up`** - **Recommended for development**. Uses additional volume mounts for local configuration and development files. This target loads both the main `docker-compose.yml` and the local override file `docker/docker-local-override.yaml`.
+
+- **`make loop_up`** - **Vanilla installation**. Uses only the base Docker Compose configuration without local development overrides. Use this when you need to test the application in a configuration closer to production or for troubleshooting configuration issues.
 
 Once the containers are running visit [https://localhost:33000/pun/sys/loop](https://localhost:33000/pun/sys/loop) and log in with the test user `ood/ood`.
 
@@ -80,8 +88,10 @@ You may also override `OOD_IMAGE` to use another container that already has Open
 |---------------------------|----------------------------------------------------------------------|
 | `make loop_docker_builder`| Build the Docker image used for compiling the app                    |
 | `make loop_build`         | Install dependencies and build the application under `application/`  |
-| `make loop_up`            | Start the local environment                                          |
-| `make loop_down`          | Stop and remove the containers                                       |
+| `make local_up`           | **Start the local development environment** (recommended)            |
+| `make local_down`         | **Stop and remove the development environment containers**           |
+| `make loop_up`            | Start the vanilla environment (no local overrides)                  |
+| `make loop_down`          | Stop and remove the vanilla environment containers                   |
 | `make clean`              | Remove build artifacts and log files                                 |
 | `make logs`               | Tail the application logs                                            |
 | `make bash`               | Open a shell inside the running container                            |


### PR DESCRIPTION
## Description
Created Docker compose configuration to allow running the application locally without imposing the development configuration. This might be required by other installations while they test their own configuration


## Testing
- [ ] Added/updated tests
- [ ] All tests pass locally
- [x] Tested manually (describe how)

## Documentation
- [x] Updated relevant documentation
- [ ] No documentation changes needed