### PR TITLE
feat: Use GitHub app to create releases to protect main branch

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -21,11 +21,19 @@ jobs:
       version: ${{ steps.version.outputs.version }}
 
     steps:
+      - name: Generate GitHub App token
+        id: app-token
+        uses: actions/create-github-app-token@v1
+        with:
+          app-id: ${{ secrets.APP_ID }}
+          private-key: ${{ secrets.APP_PRIVATE_KEY }}
+
       - name: Checkout Loop SRC
         uses: actions/checkout@v4
         with:
           fetch-depth: 0
           path: src
+          token: ${{ steps.app-token.outputs.token }}
 
       - name: Git setup
         working-directory: src

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -11,8 +11,17 @@ jobs:
     name: Run tests
     runs-on: ubuntu-latest
     steps:
+      - name: Generate GitHub App token
+        id: app-token
+        uses: actions/create-github-app-token@v1
+        with:
+          app-id: ${{ secrets.APP_ID }}
+          private-key: ${{ secrets.APP_PRIVATE_KEY }}
+
       - name: Checkout ${{ github.sha }}
         uses: actions/checkout@v4
+        with:
+          token: ${{ steps.app-token.outputs.token }}
 
       - name: Run tests
         run: make test
@@ -25,8 +34,17 @@ jobs:
     permissions:
       contents: write
     steps:
+      - name: Generate GitHub App token
+        id: app-token
+        uses: actions/create-github-app-token@v1
+        with:
+          app-id: ${{ secrets.APP_ID }}
+          private-key: ${{ secrets.APP_PRIVATE_KEY }}
+
       - name: Checkout ${{ github.sha }}
         uses: actions/checkout@v4
+        with:
+          token: ${{ steps.app-token.outputs.token }}
 
       - name: Generate coverage & badges
         run: make coverage


### PR DESCRIPTION
## Description
Update release tasks that commit to main to use an organization GitHub app so that we can protect the main branch and create releases.

## Related Issue
Fixes #474

## Testing
- [ ] Added/updated tests
- [ ] All tests pass locally
- [ ] Tested manually (describe how)

## Documentation
- [ ] Updated relevant documentation
- [ ] No documentation changes needed