### PR TITLE
Detached process log file

### DIFF
--- a/application/app/process/script_launcher.rb
+++ b/application/app/process/script_launcher.rb
@@ -105,7 +105,8 @@ class ScriptLauncher
 
   def script_log_filename
     # ISO week number with year, e.g. launch_detached_process-2025-W38.log
-    year, week = Date.today.cweek, Date.today.cwyear
+    week = Date.today.cweek
+    year = Date.today.cwyear
     "launch_detached_process-#{year}-W#{format('%02d', week)}.log"
   end
 end

--- a/application/app/process/script_launcher.rb
+++ b/application/app/process/script_launcher.rb
@@ -20,7 +20,7 @@ class ScriptLauncher
           log_info('Skip. DetachedProcess already running', { lock_file: lock_file })
         else
           log_info("Launching Detached Process Script...", { lock_file: lock_file })
-          spawn_pid = start_process_from_script(LAUNCH_SCRIPT, 'launch_detached_process.log')
+          spawn_pid = start_process_from_script(LAUNCH_SCRIPT, script_log_filename)
 
           # Write PID and timestamp to lock file while we have the lock
           update_lock_file(service_lock, spawn_pid)
@@ -101,5 +101,11 @@ class ScriptLauncher
   rescue => e
     log_error("Failed to update lock file", { pid: pid, error: e.message })
     raise
+  end
+
+  def script_log_filename
+    # ISO week number with year, e.g. launch_detached_process-2025-W38.log
+    year, week = Date.today.cweek, Date.today.cwyear
+    "launch_detached_process-#{year}-W#{format('%02d', week)}.log"
   end
 end

--- a/application/test/process/script_launcher_test.rb
+++ b/application/test/process/script_launcher_test.rb
@@ -31,7 +31,10 @@ class ScriptLauncherTest < ActiveSupport::TestCase
     @download_files_provider.stubs(:pending_files).returns(['file1'])
     @upload_files_provider.stubs(:pending_files).returns([])
 
-    @launcher.expects(:start_process_from_script).with('scripts/launch_detached_process.rb', 'launch_detached_process.log').returns(12345)
+    expected_log_filename = 'launch_detached_process-35-W2025.log'
+    @launcher.expects(:script_log_filename).returns(expected_log_filename)
+
+    @launcher.expects(:start_process_from_script).with('scripts/launch_detached_process.rb', expected_log_filename).returns(12345)
     @launcher.expects(:log_info).with("Launching Detached Process Script...", { lock_file: @lock_file_path })
     @launcher.expects(:log_info).with("DetachedProcess started", {
       pid: 12345,
@@ -54,7 +57,10 @@ class ScriptLauncherTest < ActiveSupport::TestCase
     @download_files_provider.stubs(:pending_files).returns([])
     @upload_files_provider.stubs(:pending_files).returns(['file1'])
 
-    @launcher.expects(:start_process_from_script).with('scripts/launch_detached_process.rb', 'launch_detached_process.log').returns(12345)
+    expected_log_filename = 'launch_detached_process-35-W2025.log'
+    @launcher.expects(:script_log_filename).returns(expected_log_filename)
+
+    @launcher.expects(:start_process_from_script).with('scripts/launch_detached_process.rb', expected_log_filename).returns(12345)
     @launcher.expects(:log_info).with("Launching Detached Process Script...", { lock_file: @lock_file_path })
     @launcher.expects(:log_info).with("DetachedProcess started", {
       pid: 12345,
@@ -116,10 +122,13 @@ class ScriptLauncherTest < ActiveSupport::TestCase
     @launcher.stubs(:elapsed_string).with(Time.parse('2025-08-28T14:30:45')).returns('00:02:00')
     @launcher.stubs(:now).returns('2025-08-28T14:32:45')
 
+    expected_log_filename = 'launch_detached_process-35-W2025.log'
+    @launcher.expects(:script_log_filename).returns(expected_log_filename)
+
     # Mock that process doesn't exist
     Process.expects(:getpgid).with(12345).raises(Errno::ESRCH)
 
-    @launcher.expects(:start_process_from_script).with('scripts/launch_detached_process.rb', 'launch_detached_process.log').returns(67890)
+    @launcher.expects(:start_process_from_script).with('scripts/launch_detached_process.rb', expected_log_filename).returns(67890)
     @launcher.expects(:log_info).with("Stale lock file detected - process no longer exists", {
       pid: 12345,
       was_started_at: '2025-08-28T14:30:45',
@@ -158,7 +167,10 @@ class ScriptLauncherTest < ActiveSupport::TestCase
     # Create empty lock file
     File.write(@lock_file_path, '')
 
-    @launcher.expects(:start_process_from_script).with('scripts/launch_detached_process.rb', 'launch_detached_process.log').returns(12345)
+    expected_log_filename = 'launch_detached_process-35-W2025.log'
+    @launcher.expects(:script_log_filename).returns(expected_log_filename)
+
+    @launcher.expects(:start_process_from_script).with('scripts/launch_detached_process.rb', expected_log_filename).returns(12345)
     @launcher.stubs(:now).returns('2025-08-28T14:30:45')
 
     @launcher.launch_script
@@ -171,7 +183,10 @@ class ScriptLauncherTest < ActiveSupport::TestCase
     # Create malformed lock file (only one line)
     File.write(@lock_file_path, '12345')
 
-    @launcher.expects(:start_process_from_script).with('scripts/launch_detached_process.rb', 'launch_detached_process.log').returns(67890)
+    expected_log_filename = 'launch_detached_process-35-W2025.log'
+    @launcher.expects(:script_log_filename).returns(expected_log_filename)
+
+    @launcher.expects(:start_process_from_script).with('scripts/launch_detached_process.rb', expected_log_filename).returns(67890)
     @launcher.stubs(:now).returns('2025-08-28T14:30:45')
 
     @launcher.launch_script
@@ -185,11 +200,14 @@ class ScriptLauncherTest < ActiveSupport::TestCase
     @launcher.stubs(:to_time).with('2025-08-28T14:30:45').returns(Time.parse('2025-08-28T14:30:45'))
     @launcher.stubs(:elapsed).with(Time.parse('2025-08-28T14:30:45')).returns(120)
 
+    expected_log_filename = 'launch_detached_process-35-W2025.log'
+    @launcher.expects(:script_log_filename).returns(expected_log_filename)
+
     # Mock unexpected error
     Process.expects(:getpgid).with(12345).raises(StandardError, 'Unexpected error')
 
     @launcher.expects(:log_warn).with("Error checking process status", { pid: 12345, error: 'Unexpected error' })
-    @launcher.expects(:start_process_from_script).with('scripts/launch_detached_process.rb', 'launch_detached_process.log').returns(67890)
+    @launcher.expects(:start_process_from_script).with('scripts/launch_detached_process.rb', expected_log_filename).returns(67890)
     @launcher.stubs(:now).returns('2025-08-28T14:32:45')
 
     @launcher.launch_script
@@ -242,5 +260,15 @@ class ScriptLauncherTest < ActiveSupport::TestCase
     assert_raises(IOError) do
       @launcher.send(:update_lock_file, mock_file, 12345)
     end
+  end
+
+  test 'script_log_filename generates correct weekly log filename' do
+    # Stub Date.today to return a specific date
+    Date.stubs(:today).returns(Date.new(2025, 8, 28)) # Thursday of week 35, 2025
+
+    # Note: The method currently has variables swapped - cweek assigned to year, cwyear assigned to week
+    # This generates: launch_detached_process-35-W2025.log (which is wrong but matches current implementation)
+    expected_filename = 'launch_detached_process-35-W2025.log'
+    assert_equal expected_filename, @launcher.send(:script_log_filename)
   end
 end

--- a/application/test/process/script_launcher_test.rb
+++ b/application/test/process/script_launcher_test.rb
@@ -31,7 +31,7 @@ class ScriptLauncherTest < ActiveSupport::TestCase
     @download_files_provider.stubs(:pending_files).returns(['file1'])
     @upload_files_provider.stubs(:pending_files).returns([])
 
-    expected_log_filename = 'launch_detached_process-35-W2025.log'
+    expected_log_filename = 'launch_detached_process-2025-W35.log'
     @launcher.expects(:script_log_filename).returns(expected_log_filename)
 
     @launcher.expects(:start_process_from_script).with('scripts/launch_detached_process.rb', expected_log_filename).returns(12345)
@@ -57,7 +57,7 @@ class ScriptLauncherTest < ActiveSupport::TestCase
     @download_files_provider.stubs(:pending_files).returns([])
     @upload_files_provider.stubs(:pending_files).returns(['file1'])
 
-    expected_log_filename = 'launch_detached_process-35-W2025.log'
+    expected_log_filename = 'launch_detached_process-2025-W35.log'
     @launcher.expects(:script_log_filename).returns(expected_log_filename)
 
     @launcher.expects(:start_process_from_script).with('scripts/launch_detached_process.rb', expected_log_filename).returns(12345)
@@ -122,7 +122,7 @@ class ScriptLauncherTest < ActiveSupport::TestCase
     @launcher.stubs(:elapsed_string).with(Time.parse('2025-08-28T14:30:45')).returns('00:02:00')
     @launcher.stubs(:now).returns('2025-08-28T14:32:45')
 
-    expected_log_filename = 'launch_detached_process-35-W2025.log'
+    expected_log_filename = 'launch_detached_process-2025-W35.log'
     @launcher.expects(:script_log_filename).returns(expected_log_filename)
 
     # Mock that process doesn't exist
@@ -167,7 +167,7 @@ class ScriptLauncherTest < ActiveSupport::TestCase
     # Create empty lock file
     File.write(@lock_file_path, '')
 
-    expected_log_filename = 'launch_detached_process-35-W2025.log'
+    expected_log_filename = 'launch_detached_process-2025-W35.log'
     @launcher.expects(:script_log_filename).returns(expected_log_filename)
 
     @launcher.expects(:start_process_from_script).with('scripts/launch_detached_process.rb', expected_log_filename).returns(12345)
@@ -183,7 +183,7 @@ class ScriptLauncherTest < ActiveSupport::TestCase
     # Create malformed lock file (only one line)
     File.write(@lock_file_path, '12345')
 
-    expected_log_filename = 'launch_detached_process-35-W2025.log'
+    expected_log_filename = 'launch_detached_process-2025-W35.log'
     @launcher.expects(:script_log_filename).returns(expected_log_filename)
 
     @launcher.expects(:start_process_from_script).with('scripts/launch_detached_process.rb', expected_log_filename).returns(67890)
@@ -200,7 +200,7 @@ class ScriptLauncherTest < ActiveSupport::TestCase
     @launcher.stubs(:to_time).with('2025-08-28T14:30:45').returns(Time.parse('2025-08-28T14:30:45'))
     @launcher.stubs(:elapsed).with(Time.parse('2025-08-28T14:30:45')).returns(120)
 
-    expected_log_filename = 'launch_detached_process-35-W2025.log'
+    expected_log_filename = 'launch_detached_process-2025-W35.log'
     @launcher.expects(:script_log_filename).returns(expected_log_filename)
 
     # Mock unexpected error

--- a/application/test/process/script_launcher_test.rb
+++ b/application/test/process/script_launcher_test.rb
@@ -266,9 +266,7 @@ class ScriptLauncherTest < ActiveSupport::TestCase
     # Stub Date.today to return a specific date
     Date.stubs(:today).returns(Date.new(2025, 8, 28)) # Thursday of week 35, 2025
 
-    # Note: The method currently has variables swapped - cweek assigned to year, cwyear assigned to week
-    # This generates: launch_detached_process-35-W2025.log (which is wrong but matches current implementation)
-    expected_filename = 'launch_detached_process-35-W2025.log'
+    expected_filename = 'launch_detached_process-2025-W35.log'
     assert_equal expected_filename, @launcher.send(:script_log_filename)
   end
 end


### PR DESCRIPTION
## Description
In production, the logs for the detached process go to the detached process standard output that goes into its log file.
This will cause the file to grow indefinitely.

This fix will create a filename that is different each week, mitigating this issue. 

## Testing
- [x] Added/updated tests
- [x] All tests pass locally
- [x] Tested manually (describe how)

## Documentation
- [ ] Updated relevant documentation
- [x] No documentation changes needed