### PR TITLE
fix: Fixed GH test action to not require APP token

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -11,17 +11,8 @@ jobs:
     name: Run tests
     runs-on: ubuntu-latest
     steps:
-      - name: Generate GitHub App token
-        id: app-token
-        uses: actions/create-github-app-token@v1
-        with:
-          app-id: ${{ secrets.APP_ID }}
-          private-key: ${{ secrets.APP_PRIVATE_KEY }}
-
       - name: Checkout ${{ github.sha }}
         uses: actions/checkout@v4
-        with:
-          token: ${{ steps.app-token.outputs.token }}
 
       - name: Run tests
         run: make test


### PR DESCRIPTION
## Description
Dependa Bot PRs are failing as test require an AP token and this is not allowed from external forks.
App token is not required to run the tests, just to create and commit the badges on main commit

## Testing
- [ ] Added/updated tests
- [ ] All tests pass locally
- [ ] Tested manually (describe how)

## Documentation
- [ ] Updated relevant documentation
- [x] No documentation changes needed