### PR TITLE
fix: Fixed error for missing or invalid files

### DIFF
--- a/application/app/helpers/file_browser_helper.rb
+++ b/application/app/helpers/file_browser_helper.rb
@@ -1,0 +1,11 @@
+# frozen_string_literal: true
+
+module FileBrowserHelper
+
+  def browser_entry_icon(entry)
+    return 'bi-folder-fill' if entry.folder?
+    return 'bi-file-earmark' if entry.file?
+
+    'bi-slash-circle'
+  end
+end

--- a/application/app/views/file_browser/_browser.html.erb
+++ b/application/app/views/file_browser/_browser.html.erb
@@ -4,6 +4,17 @@
     <!-- Path display (left) -->
     <nav aria-label="<%= t('.nav_file_browser_label') %>">
       <ol data-file-browser-target="pathDisplay" class="breadcrumb d-flex align-items-center flex-wrap gap-2 mb-0">
+        <!-- Root link -->
+        <li>
+          <a class="breadcrumb-folder text-body text-decoration-none"
+             tabindex="0"
+             data-entry-path="/"
+             data-entry-type="folder"
+             data-action="dblclick->file-browser#handleDoubleClick keydown->file-browser#handleKeydown">
+            <i class="bi bi-diagram-3"></i>
+          </a>
+        </li>
+
         <% path_parts = current_path.split('/').reject(&:blank?) %>
         <% accumulated_path = '/' %>
         <% path_parts.each do |part| %>
@@ -79,7 +90,7 @@
 
   <div class="card-body p-0 overflow-auto" style="height: 500px;">
     <ul class="list-group list-group-flush">
-      <% if true %>
+      <% unless path_parts.empty? %>
         <li class="list-group-item d-flex align-items-center gap-3 file-row text-muted"
             data-entry-path="<%= File.expand_path('..', current_path) %>"
             data-entry-type="folder"
@@ -91,7 +102,7 @@
       <% end %>
 
       <% entries.each do |entry| %>
-        <li class="list-group-item d-flex align-items-center gap-3 file-row"
+        <li class="list-group-item d-flex align-items-center gap-3 file-row <%= 'disabled opacity-50' unless entry.supported? %>"
             data-entry-path="<%= entry.path %>"
             data-entry-type="<%= entry.type %>"
             draggable="true"
@@ -99,13 +110,13 @@
             data-action="dragstart->file-browser#handleDragStart dragend->file-browser#handleDragEnd dblclick->file-browser#handleDoubleClick keydown->file-browser#handleKeydown">
 
           <!-- Icon -->
-          <i class="bi <%= entry[:type] == 'folder' ? 'bi-folder-fill' : 'bi-file-earmark' %> fs-5 text-secondary" aria-hidden="true"></i>
+          <i class="bi <%= browser_entry_icon(entry) %> fs-5 text-secondary" aria-hidden="true"></i>
 
           <!-- Name -->
           <span class="flex-grow-1"><%= entry.name %></span>
 
           <!-- File Size -->
-          <% if entry.type == 'file' %>
+          <% if entry.file? %>
             <small class="text-muted"><%= number_to_human_size(entry.size) %></small>
           <% end %>
         </li>

--- a/application/test/controllers/file_browser_controller_test.rb
+++ b/application/test/controllers/file_browser_controller_test.rb
@@ -36,4 +36,79 @@ class FileBrowserControllerTest < ActionDispatch::IntegrationTest
     assert_response :success
     assert_includes @response.body, 'subfile.txt'
   end
+
+  test 'should sort entries with folders first' do
+    get file_browser_url, params: { path: @tmp_dir }
+    assert_response :success
+
+    # Extract entry order from response (this assumes the partial renders entries in order)
+    assert_match /subdir.*testfile\.txt/m, @response.body
+  end
+end
+
+class DirectoryEntryTest < ActiveSupport::TestCase
+  def setup
+    @tmp_dir = Dir.mktmpdir
+    @sub_dir = File.join(@tmp_dir, "subdir")
+    Dir.mkdir(@sub_dir)
+    @file = File.join(@tmp_dir, "testfile.txt")
+    File.write(@file, "test content")
+  end
+
+  def teardown
+    FileUtils.rm_rf(@tmp_dir)
+  end
+
+  test 'should initialize with name and path' do
+    entry = FileBrowserController.send(:const_get, :DirectoryEntry).new(name: "test.txt", path: @file)
+
+    assert_equal "test.txt", entry.name
+    assert_equal @file, entry.path
+    assert_equal File.size(@file), entry.size
+    assert_equal "file", entry.type
+  end
+
+  test 'should detect file type correctly' do
+    file_entry = FileBrowserController.send(:const_get, :DirectoryEntry).new(name: "test.txt", path: @file)
+
+    assert file_entry.file?
+    assert_not file_entry.folder?
+    assert file_entry.supported?
+  end
+
+  test 'should detect folder type correctly' do
+    folder_entry = FileBrowserController.send(:const_get, :DirectoryEntry).new(name: "subdir", path: @sub_dir)
+
+    assert folder_entry.folder?
+    assert_not folder_entry.file?
+    assert folder_entry.supported?
+  end
+
+  test 'should return correct type_order' do
+    file_entry = FileBrowserController.send(:const_get, :DirectoryEntry).new(name: "test.txt", path: @file)
+    folder_entry = FileBrowserController.send(:const_get, :DirectoryEntry).new(name: "subdir", path: @sub_dir)
+
+    assert_equal 1, file_entry.type_order  # Files come after folders
+    assert_equal 0, folder_entry.type_order  # Folders come first
+  end
+
+  test 'should handle unsupported file types' do
+    # Create a mock entry that doesn't match file or directory
+    entry = FileBrowserController.send(:const_get, :DirectoryEntry).new(name: "test.txt", path: @file)
+    entry.instance_variable_set(:@type, 'link')  # Simulate unsupported type
+
+    assert_not entry.file?
+    assert_not entry.folder?
+    assert_not entry.supported?
+    assert_equal 2, entry.type_order  # Others go last
+  end
+
+  test 'should calculate size correctly' do
+    content = "test content with more data"
+    File.write(@file, content)
+
+    entry = FileBrowserController.send(:const_get, :DirectoryEntry).new(name: "test.txt", path: @file)
+
+    assert_equal content.bytesize, entry.size
+  end
 end

--- a/application/test/helpers/file_browser_helper_test.rb
+++ b/application/test/helpers/file_browser_helper_test.rb
@@ -1,0 +1,46 @@
+# frozen_string_literal: true
+require 'test_helper'
+
+class FileBrowserHelperTest < ActionView::TestCase
+  include FileBrowserHelper
+
+  test 'browser_entry_icon returns folder icon for folders' do
+    File.stubs(:directory?).with('/path/to/folder').returns(true)
+    File.stubs(:file?).with('/path/to/folder').returns(false)
+    File.stubs(:size).with('/path/to/folder').returns(4096)
+
+    folder_entry = FileBrowserController::DirectoryEntry.new(name: "subdir", path: "/path/to/folder")
+
+    assert_equal 'bi-folder-fill', browser_entry_icon(folder_entry)
+  end
+
+  test 'browser_entry_icon returns file icon for files' do
+    File.stubs(:directory?).with('/path/to/file.txt').returns(false)
+    File.stubs(:file?).with('/path/to/file.txt').returns(true)
+    File.stubs(:size).with('/path/to/file.txt').returns(1024)
+
+    file_entry = FileBrowserController::DirectoryEntry.new(name: "testfile.txt", path: "/path/to/file.txt")
+
+    assert_equal 'bi-file-earmark', browser_entry_icon(file_entry)
+  end
+
+  test 'browser_entry_icon returns unsupported icon for unsupported types' do
+    File.stubs(:directory?).with('/path/to/link').returns(false)
+    File.stubs(:file?).with('/path/to/link').returns(false)
+    File.stubs(:size).with('/path/to/link').returns(0)
+
+    unsupported_entry = FileBrowserController::DirectoryEntry.new(name: "test.link", path: "/path/to/link")
+
+    assert_equal 'bi-slash-circle', browser_entry_icon(unsupported_entry)
+  end
+
+  test 'browser_entry_icon handles edge case when entry is neither file nor folder' do
+    File.stubs(:directory?).with('/path/to/special').returns(false)
+    File.stubs(:file?).with('/path/to/special').returns(false)
+    File.stubs(:size).with('/path/to/special').returns(0)
+
+    unsupported_entry = FileBrowserController::DirectoryEntry.new(name: "special", path: "/path/to/special")
+
+    assert_equal 'bi-slash-circle', browser_entry_icon(unsupported_entry)
+  end
+end


### PR DESCRIPTION
## Description
 - Fixes to file browser for missing or invalid files.
 - Added icon to navigate to root folder
 - Removed `.. (Parent Directory) `link when in root

## Related Issue
Fixes #498 

## Testing
- [x] Added/updated tests
- [x] All tests pass locally
- [x] Tested manually (describe how)

## Documentation
- [ ] Updated relevant documentation
- [x] No documentation changes needed