### PR TITLE
feat: Added support to retry cancelled or error uploads

### DIFF
--- a/application/app/controllers/download_files_controller.rb
+++ b/application/app/controllers/download_files_controller.rb
@@ -3,65 +3,58 @@ class DownloadFilesController < ApplicationController
   include LoggingCommon
   include EventLogger
 
+  before_action :find_file
+
   def cancel
-    project_id = params[:project_id]
-    file_id = params[:id]
-    file = DownloadFile.find(project_id, file_id)
-
-    if file.nil?
-      return redirect_back fallback_location: root_path, alert: t('download_files.file_not_found', file_id: file_id, project_id: project_id)
-    end
-
-    previous_status = file.status.to_s
-    if file.status.downloading?
+    previous_status = @file.status.to_s
+    if @file.status.downloading?
       command_client = Command::CommandClient.new(socket_path: ::Configuration.command_server_socket_file)
-      request = Command::Request.new(command: 'download.cancel', body: {project_id: project_id, file_id: file_id})
+      request = Command::Request.new(command: 'download.cancel', body: {project_id: @file.project_id, file_id: @file.id})
       response = command_client.request(request)
-      return redirect_back fallback_location: root_path, alert: t('download_files.file_cancellation_error', filename: file.filename) if response.status != 200
+      return redirect_back fallback_location: root_path, alert: t('download_files.file_cancellation_error', filename: @file.filename) if response.status != 200
     end
 
-    if file.update(status: FileStatus::CANCELLED)
-      log_download_file_event(file, message: 'events.download_file.cancel_completed', metadata: { filename: file.filename, previous_status: previous_status })
-      redirect_back fallback_location: root_path, notice: t('download_files.file_cancellation_success', filename: file.filename)
+    if @file.update(status: FileStatus::CANCELLED)
+      log_download_file_event(@file, message: 'events.download_file.cancel_completed', metadata: { filename: @file.filename, previous_status: previous_status })
+      log_info('Download file cancelled', {id: @file.id, filename: @file.filename})
+      redirect_back fallback_location: root_path, notice: t('download_files.file_cancellation_success', filename: @file.filename)
     else
-      redirect_back fallback_location: root_path, alert: t('download_files.file_cancellation_update_error', filename: file.filename)
-    end
-  end
-
-  def update
-    project_id = params[:project_id]
-    file_id = params[:id]
-    state = params[:state]
-    file = DownloadFile.find(project_id, file_id)
-
-    if file.nil?
-      redirect_back fallback_location: root_path, alert: t('download_files.file_not_found', file_id: file_id, project_id: project_id)
-      return
-    end
-
-    if file.update(status: FileStatus.get(state))
-      redirect_back fallback_location: root_path, notice: t('download_files.file_update_success', filename: file.filename)
-    else
-      redirect_back fallback_location: root_path, alert: t('download_files.file_update_error', filename: file.filename)
+      redirect_back fallback_location: root_path, alert: t('download_files.file_cancellation_update_error', filename: @file.filename)
     end
   end
 
   def destroy
+    if @file.status.downloading?
+      redirect_back fallback_location: root_path, alert: t('download_files.file_in_progress', filename: @file.filename)
+      return
+    end
+
+    @file.destroy
+    log_info('Download file deleted', {id: @file.id, filename: @file.filename})
+    redirect_back fallback_location: root_path, notice: t('download_files.file_deletion_success', filename: @file.filename)
+  end
+
+  def retry
+    previous_status = @file.status
+    if @file.update(status: FileStatus::PENDING)
+      log_download_file_event(@file, message: 'events.download_file.retry_request', metadata: { filename: @file.filename, previous_status: previous_status })
+      log_info('Download file retry requested', {id: @file.id, filename: @file.filename})
+      redirect_back fallback_location: root_path, notice: t('download_files.file_retry_success', filename: @file.filename)
+    else
+      redirect_back fallback_location: root_path, alert: t('download_files.file_retry_error', filename: @file.filename)
+    end
+  end
+
+  private
+
+  def find_file
     project_id = params[:project_id]
     file_id = params[:id]
-    file = DownloadFile.find(project_id, file_id)
-    if file.nil?
+    @file = DownloadFile.find(project_id, file_id)
+
+    if @file.nil?
       redirect_back fallback_location: root_path, alert: t('download_files.file_not_found', file_id: file_id, project_id: project_id)
-      return
     end
-
-    if file.status.downloading?
-      redirect_back fallback_location: root_path, alert: t('download_files.file_in_progress', filename: file.filename)
-      return
-    end
-
-    file.destroy
-    redirect_back fallback_location: root_path, notice: t('download_files.file_deletion_success', filename: file.filename)
   end
 
 end

--- a/application/app/controllers/download_files_controller.rb
+++ b/application/app/controllers/download_files_controller.rb
@@ -15,7 +15,7 @@ class DownloadFilesController < ApplicationController
     end
 
     if @file.update(status: FileStatus::CANCELLED)
-      log_download_file_event(@file, message: 'events.download_file.cancel_completed', metadata: { filename: @file.filename, previous_status: previous_status })
+      log_download_file_event(@file, message: 'events.download_file.cancel_completed', metadata: { previous_status: previous_status })
       log_info('Download file cancelled', {id: @file.id, filename: @file.filename})
       redirect_back fallback_location: root_path, notice: t('download_files.file_cancellation_success', filename: @file.filename)
     else
@@ -30,6 +30,7 @@ class DownloadFilesController < ApplicationController
     end
 
     @file.destroy
+    log_download_file_event(@file, message: 'events.download_file.deleted')
     log_info('Download file deleted', {id: @file.id, filename: @file.filename})
     redirect_back fallback_location: root_path, notice: t('download_files.file_deletion_success', filename: @file.filename)
   end
@@ -37,7 +38,7 @@ class DownloadFilesController < ApplicationController
   def retry
     previous_status = @file.status
     if @file.update(status: FileStatus::PENDING)
-      log_download_file_event(@file, message: 'events.download_file.retry_request', metadata: { filename: @file.filename, previous_status: previous_status })
+      log_download_file_event(@file, message: 'events.download_file.retry_request', metadata: { previous_status: previous_status })
       log_info('Download file retry requested', {id: @file.id, filename: @file.filename})
       redirect_back fallback_location: root_path, notice: t('download_files.file_retry_success', filename: @file.filename)
     else

--- a/application/app/controllers/upload_files_controller.rb
+++ b/application/app/controllers/upload_files_controller.rb
@@ -53,6 +53,7 @@ class UploadFilesController < ApplicationController
     end
 
     @upload_file.destroy
+    log_upload_file_event(@upload_file, message: 'events.upload_file.deleted')
     log_info('Upload file deleted', {id: @upload_file.id, filename: @upload_file.filename})
     redirect_back fallback_location: root_path, notice: t(".upload_file_removed", filename: @upload_file.filename)
   end
@@ -67,7 +68,7 @@ class UploadFilesController < ApplicationController
     end
 
     if @upload_file.update(status: FileStatus::CANCELLED)
-      log_upload_file_event(@upload_file, message: 'events.upload_file.cancel_completed', metadata: { filename: @upload_file.filename, previous_status: previous_status })
+      log_upload_file_event(@upload_file, message: 'events.upload_file.cancel_completed', metadata: { previous_status: previous_status })
       log_info('Upload file cancelled', {id: @upload_file.id, filename: @upload_file.filename})
       redirect_back fallback_location: root_path, notice: t('.file_cancellation_success', filename: @upload_file.filename)
     else
@@ -78,7 +79,7 @@ class UploadFilesController < ApplicationController
   def retry
     previous_status = @upload_file.status
     if @upload_file.update(status: FileStatus::PENDING)
-      log_upload_file_event(@upload_file, message: 'events.upload_file.retry_request', metadata: { filename: @upload_file.filename, previous_status: previous_status })
+      log_upload_file_event(@upload_file, message: 'events.upload_file.retry_request', metadata: { previous_status: previous_status })
       log_info('Upload file retry requested', {id: @upload_file.id, filename: @upload_file.filename})
       redirect_back fallback_location: root_path, notice: t('.file_retry_success', filename: @upload_file.filename)
     else

--- a/application/app/controllers/upload_files_controller.rb
+++ b/application/app/controllers/upload_files_controller.rb
@@ -5,30 +5,22 @@ class UploadFilesController < ApplicationController
   include DateTimeCommon
   include EventLogger
 
+  before_action :find_upload_file, only: [:destroy, :cancel, :retry]
+  before_action :find_bundle, only: [:index, :create]
+
   def index
-    project_id = params[:project_id]
-    upload_bundle_id = params[:upload_bundle_id]
-    upload_bundle = UploadBundle.find(project_id, upload_bundle_id)
-    render partial: '/projects/show/upload_files', layout: false, locals: { bundle: upload_bundle }
+    render partial: '/projects/show/upload_files', layout: false, locals: { bundle: @upload_bundle }
   end
 
   # JSON based create method to add a local filepath to an upload bundle
   def create
-    project_id = params[:project_id]
-    upload_bundle_id = params[:upload_bundle_id]
-    upload_bundle = UploadBundle.find(project_id, upload_bundle_id)
-    if upload_bundle.nil?
-      head :not_found
-      return
-    end
-
     path = params[:path]
     files = list_files(path)
     upload_files = files.map do |file|
       UploadFile.new.tap do |f|
         f.id = UploadFile.generate_id
-        f.project_id = project_id
-        f.upload_bundle_id = upload_bundle_id
+        f.project_id = @upload_bundle.project_id
+        f.upload_bundle_id = @upload_bundle.id
         f.creation_date = now
         f.file_location = file.fullpath
         f.filename = file.filename
@@ -40,7 +32,7 @@ class UploadFilesController < ApplicationController
     upload_files.each do |file|
       unless file.valid?
         errors = file.errors.full_messages.join(", ")
-        log_error('UploadFile validation error', {error: errors, project_id: project_id, upload_bundle_id: upload_bundle_id, file: file.to_s})
+        log_error('UploadFile validation error', {error: errors, project_id: @upload_bundle.project_id, upload_bundle_id: @upload_bundle.id, file: file.to_s})
         render json: { message: t(".invalid_file", filename: file.filename, errors: errors) }, status: :bad_request
         return
       end
@@ -48,7 +40,7 @@ class UploadFilesController < ApplicationController
 
     upload_files.each do |file|
       file.save
-      log_info('Added file to upload bundle', {project_id: project_id, upload_bundle_id: upload_bundle_id, file: file.filename})
+      log_info('Added file to upload bundle', {project_id: @upload_bundle.project_id, upload_bundle_id: @upload_bundle.id, file: file.filename})
     end
 
     message = upload_files.size > 1 ? t(".files_added", count: upload_files.size, path_folder: path) : t(".file_added", filename: upload_files.first.filename)
@@ -56,52 +48,73 @@ class UploadFilesController < ApplicationController
   end
 
   def destroy
-    project_id = params[:project_id]
-    upload_bundle_id = params[:upload_bundle_id]
-    file_id = params[:id]
-    upload_file = UploadFile.find(project_id, upload_bundle_id, file_id)
-
-    if upload_file.nil?
-      redirect_back fallback_location: root_path, alert: t(".file_not_found", file_id: file_id, project_id: project_id)
-      return
+    if @upload_file.status.uploading?
+      return redirect_back fallback_location: root_path, alert: t(".file_in_progress", filename: @upload_file.filename)
     end
 
-    if upload_file.status.uploading?
-      redirect_back fallback_location: root_path, alert: t(".file_in_progress", filename: upload_file.filename)
-      return
-    end
-
-    upload_file.destroy
-    redirect_back fallback_location: root_path, notice: t(".upload_file_removed", filename: upload_file.filename)
+    @upload_file.destroy
+    log_info('Upload file deleted', {id: @upload_file.id, filename: @upload_file.filename})
+    redirect_back fallback_location: root_path, notice: t(".upload_file_removed", filename: @upload_file.filename)
   end
 
   def cancel
-    project_id = params[:project_id]
-    upload_bundle_id = params[:upload_bundle_id]
-    file_id = params[:id]
-    file = UploadFile.find(project_id, upload_bundle_id, file_id)
-
-    if file.nil?
-      return redirect_back fallback_location: root_path, alert: t(".file_not_found", project_id: project_id, upload_bundle_id: upload_bundle_id, file_id: file_id)
-    end
-
-    previous_status = file.status.to_s
-    if file.status.uploading?
+    previous_status = @upload_file.status.to_s
+    if @upload_file.status.uploading?
       command_client = Command::CommandClient.new(socket_path: ::Configuration.command_server_socket_file)
-      request = Command::Request.new(command: 'upload.cancel', body: { project_id: project_id, upload_bundle_id: upload_bundle_id, file_id: file_id})
+      request = Command::Request.new(command: 'upload.cancel', body: { project_id: @upload_file.project_id, upload_bundle_id: @upload_file.upload_bundle_id, file_id: @upload_file.id})
       response = command_client.request(request)
-      return redirect_back fallback_location: root_path, alert: t('.file_cancellation_error', filename: file.filename) if response.status != 200
+      return redirect_back fallback_location: root_path, alert: t('.file_cancellation_error', filename: @upload_file.filename) if response.status != 200
     end
 
-    if file.update(status: FileStatus::CANCELLED)
-      log_upload_file_event(file, message: 'events.upload_file.cancel_completed', metadata: { filename: file.filename, previous_status: previous_status })
-      redirect_back fallback_location: root_path, notice: t('.file_cancellation_success', filename: file.filename)
+    if @upload_file.update(status: FileStatus::CANCELLED)
+      log_upload_file_event(@upload_file, message: 'events.upload_file.cancel_completed', metadata: { filename: @upload_file.filename, previous_status: previous_status })
+      log_info('Upload file cancelled', {id: @upload_file.id, filename: @upload_file.filename})
+      redirect_back fallback_location: root_path, notice: t('.file_cancellation_success', filename: @upload_file.filename)
     else
-      redirect_back fallback_location: root_path, notice: t('.file_cancellation_update_error', filename: file.filename)
+      redirect_back fallback_location: root_path, notice: t('.file_cancellation_update_error', filename: @upload_file.filename)
+    end
+  end
+
+  def retry
+    previous_status = @upload_file.status
+    if @upload_file.update(status: FileStatus::PENDING)
+      log_upload_file_event(@upload_file, message: 'events.upload_file.retry_request', metadata: { filename: @upload_file.filename, previous_status: previous_status })
+      log_info('Upload file retry requested', {id: @upload_file.id, filename: @upload_file.filename})
+      redirect_back fallback_location: root_path, notice: t('.file_retry_success', filename: @upload_file.filename)
+    else
+      redirect_back fallback_location: root_path, alert: t('.file_retry_error', filename: @upload_file.filename)
     end
   end
 
   private
+
+  def find_upload_file
+    project_id = params[:project_id]
+    upload_bundle_id = params[:upload_bundle_id]
+    file_id = params[:id]
+    @upload_file = UploadFile.find(project_id, upload_bundle_id, file_id)
+
+    if @upload_file.nil?
+       redirect_back fallback_location: root_path, alert: t("upload_files.file_not_found", project_id: project_id, upload_bundle_id: upload_bundle_id, file_id: file_id)
+       return
+    end
+  end
+
+  def find_bundle
+    project_id = params[:project_id]
+    upload_bundle_id = params[:upload_bundle_id]
+    @upload_bundle = UploadBundle.find(project_id, upload_bundle_id)
+
+    if @upload_bundle.nil?
+      message = t("upload_files.bundle_not_found", project_id: project_id, upload_bundle_id: upload_bundle_id)
+      if ajax_request?
+        render json: { message: message }, status: :not_found
+      else
+        redirect_back fallback_location: root_path, alert: message
+      end
+      return
+    end
+  end
 
   def list_files(path, limit: 100)
     return [] unless File.exist?(path)

--- a/application/app/models/event.rb
+++ b/application/app/models/event.rb
@@ -14,7 +14,7 @@ class Event
     @entity_id = entity_id
     @message = message
     @creation_date = creation_date || DateTimeCommon.now
-    @metadata = metadata || {}
+    @metadata = stringify_metadata(metadata)
   end
 
   def to_h
@@ -25,11 +25,20 @@ class Event
 
   def self.from_hash(data)
     new(project_id: data['project_id'],
-        entity_type: data['entity_type'].to_s.downcase,
+        entity_type: data['entity_type'],
         entity_id: data['entity_id'],
         message: data['message'],
         metadata: data['metadata'],
         id: data['id'],
         creation_date: data['creation_date'])
+  end
+
+  private
+
+  # Convert all keys to strings, all values to strings
+  def stringify_metadata(input)
+    return {} if input.nil?
+
+    input.transform_values(&:to_s)
   end
 end

--- a/application/app/views/download_status/_files.html.erb
+++ b/application/app/views/download_status/_files.html.erb
@@ -28,7 +28,7 @@
             </div>
           </div>
 
-          <div class="download-actions col-md-2 text-end d-flex justify-content-end align-items-center" role="cell">
+          <div class="download-actions col-md-2 text-end d-flex justify-content-end align-items-center gap-1" role="cell">
             <% if data.file.status.downloading? %>
               <%= render partial: '/shared/progress_bar', locals: { progress: data.file.connector_status.download_progress, file: data.file } %>
             <% else %>
@@ -46,18 +46,16 @@
                 <span class="visually-hidden"><%= t('.button_view_events_label') %></span>
               <% end %>
             <% end %>
-            &nbsp;
+
             <% if retry_button_visible?(data.file) %>
-              <%= render layout: '/shared/button_to',
+              <%= render partial: '/shared/button_to',
                          locals: {
-                           url: project_download_file_path(project_id: data.file.project_id, id: data.file.id),
-                           method: :patch,
+                           url: retry_project_download_file_path(project_id: data.file.project_id, id: data.file.id),
+                           method: :post,
                            icon: 'bi bi-arrow-clockwise',
                            class: 'btn-icon-sm btn-outline-dark icon-hover-success',
                            title: t('.button_retry_download_title')
-                         } do %>
-                <%= hidden_field_tag :state, FileStatus::PENDING.to_s %>
-              <% end %>
+                         }%>
             <% else %>
               <%= render partial: '/shared/button_to',
                          locals: {

--- a/application/app/views/projects/show/_download_files.html.erb
+++ b/application/app/views/projects/show/_download_files.html.erb
@@ -52,17 +52,15 @@
           <%= render partial: '/shared/file_row_date', locals: { date: file.start_date, title: t('.field_download_start_date_title'), classes: 'mx-2'} if file.status.downloading? %>
 
           <% if retry_button_visible?(file) %>
-            <%= render layout: '/shared/button_to',
+            <%= render partial: '/shared/button_to',
                        locals: {
-                         url: project_download_file_path(project_id: file.project_id, id: file.id),
-                         method: :patch,
+                         url: retry_project_download_file_path(project_id: file.project_id, id: file.id),
+                         method: :post,
                          icon: 'bi bi-arrow-clockwise',
                          class: 'btn-icon-sm btn-outline-secondary icon-hover-success',
                          title: t('.button_retry_download_title'),
                          button_id: "retry-download-file-#{file.id}-btn"
-                       } do %>
-              <%= hidden_field_tag :state, FileStatus::PENDING.to_s %>
-            <% end %>
+                       } %>
           <% end %>
 
           <%= render layout: 'shared/button_to', locals: {

--- a/application/app/views/projects/show/_upload_files.html.erb
+++ b/application/app/views/projects/show/_upload_files.html.erb
@@ -44,6 +44,19 @@
         <%= render partial: '/shared/file_row_date', locals: { date: file.end_date, title: t('.field_completion_date_title'), classes: 'mx-2'} if file.end_date %>
         <%= render partial: '/shared/file_row_date', locals: { date: file.start_date, title: t('.field_download_start_date_title'), classes: 'mx-2'} if file.status.downloading? %>
 
+        <% if retry_button_visible?(file) %>
+          <%= render layout: '/shared/button_to',
+             locals: {
+               url: retry_project_upload_bundle_upload_file_path(project_id: file.project_id, upload_bundle_id: file.upload_bundle_id, id: file.id),
+               method: :post,
+               icon: 'bi bi-arrow-clockwise',
+               class: 'btn-icon-sm btn-outline-secondary icon-hover-success',
+               title: t('.button_retry_upload_title')
+             } do %>
+              <%= hidden_field_tag :anchor, tab_anchor_for(bundle) %>
+          <% end %>
+        <% end %>
+
         <%= render layout: "shared/button_to", locals: {
           url: project_upload_bundle_upload_file_path(project_id: bundle.project_id, upload_bundle_id: bundle.id, id: file.id),
           method: 'DELETE',

--- a/application/app/views/upload_status/_files.html.erb
+++ b/application/app/views/upload_status/_files.html.erb
@@ -29,7 +29,7 @@
             </div>
           </div>
 
-          <div class="upload-actions col-md-2 text-end d-flex justify-content-end align-items-center" role="cell">
+          <div class="upload-actions col-md-2 text-end d-flex justify-content-end align-items-center gap-1" role="cell">
             <% if data.file.status.uploading? %>
               <%= render partial: '/shared/progress_bar',
                          locals: { progress: data.file.connector_status.upload_progress, file: data.file } %>
@@ -40,9 +40,7 @@
                              data: {
                                controller: 'modal',
                                action: 'click->modal#load',
-                               'modal-url-value': widgets_path('events', project_id: data.file.project_id,
-                                                                      entity_type: 'upload_file',
-                                                                      entity_id: data.file.id),
+                               'modal-url-value': widgets_path('events', project_id: data.file.project_id, entity_type: 'upload_file', entity_id: data.file.id),
                                'modal-title-value': t('.button_view_events_title'),
                                'modal-id-value': 'global-modal'
                              } do %>
@@ -50,17 +48,27 @@
                 <span class="visually-hidden"><%= t('.button_view_events_label') %></span>
               <% end %>
             <% end %>
-            &nbsp;
 
-            <%= render partial: '/shared/button_to',
-                       locals: {
-                         url: cancel_project_upload_bundle_upload_file_path(project_id: data.file.project_id, upload_bundle_id: data.file.upload_bundle_id, id: data.file.id),
-                         method: :post,
-                         disabled: cancel_button_disabled?(data.file.status),
-                         icon: 'bi bi-sign-stop',
-                         class: 'btn btn-icon-sm btn-outline-dark icon-hover-danger',
-                         title: t('.button_cancel_upload_title', filename: data.file.filename)
-                       } %>
+            <% if retry_button_visible?(data.file) %>
+              <%= render partial: '/shared/button_to',
+                         locals: {
+                           url: retry_project_upload_bundle_upload_file_path(project_id: data.file.project_id, upload_bundle_id: data.file.upload_bundle_id, id: data.file.id),
+                           method: :post,
+                           icon: 'bi bi-arrow-clockwise',
+                           class: 'btn-icon-sm btn-outline-dark icon-hover-success',
+                           title: t('.button_retry_upload_title', filename: data.file.filename)
+                         } %>
+            <% else %>
+              <%= render partial: '/shared/button_to',
+                         locals: {
+                           url: cancel_project_upload_bundle_upload_file_path(project_id: data.file.project_id, upload_bundle_id: data.file.upload_bundle_id, id: data.file.id),
+                           method: :post,
+                           disabled: cancel_button_disabled?(data.file.status),
+                           icon: 'bi bi-sign-stop',
+                           class: 'btn btn-icon-sm btn-outline-dark icon-hover-danger',
+                           title: t('.button_cancel_upload_title', filename: data.file.filename)
+                         } %>
+            <% end %>
           </div>
         </div>
       <% end %>

--- a/application/config/locales/controllers/en.yml
+++ b/application/config/locales/controllers/en.yml
@@ -7,8 +7,8 @@ en:
     file_cancellation_update_error: "Download cancelled: %{filename}, but status update failed. Try again"
     file_cancellation_success: "Download cancelled for file: %{filename}"
     file_deletion_success: "Download file deleted: %{filename}"
-    file_update_success: "Download file status updated: %{filename}"
-    file_update_error: "Could not update file: %{filename}"
+    file_retry_success: "File has been moved back to the pending queue and will be downloaded again."
+    file_retry_error: "Could not move file back to the pending queue"
   file_browser:
     directory_forbidden: "You do not have permission to access this directory."
   projects:
@@ -55,19 +55,22 @@ en:
       not_found: "Upload Bundle not found: %{upload_bundle_id}"
       success: "Upload bundle deleted: %{bundle_name}"
   upload_files:
+    bundle_not_found: "Upload bundle not found for project: %{project_id} bundle: %{upload_bundle_id}"
+    file_not_found: "File: %{file_id} not found for project: %{project_id}"
     create:
       invalid_file: "Invalid file in selection: %{filename} errors: %{errors}"
       files_added: "%{count} files added from: %{path_folder}"
       file_added: "File added: %{filename}"
     destroy:
-      file_not_found: "File: %{file_id} not found for project: %{project_id}"
       file_in_progress: "File: %{filename} cannot be deleted while is being uploaded"
       upload_file_removed: "Upload file removed from bundle: %{filename}"
     cancel:
-      file_not_found: "file not found project_id=%{project_id} upload_bundle_id=%{upload_bundle_id} id=%{file_id}"
       file_cancellation_error: "Could not cancel upload for file: %{filename}"
       file_cancellation_update_error: "Upload cancelled: %{filename}, but status update failed. Try again"
       file_cancellation_success: "Upload cancelled for file: %{filename}"
+    retry:
+      file_retry_success: "File has been moved back to the pending queue and will be uploaded again."
+      file_retry_error: "Could not move file back to the pending queue"
   explore:
     show:
       message_processor_error: "Error processing request for repository: %{connector_type} type: %{object_type} with id: %{object_id}"

--- a/application/config/locales/controllers/en.yml
+++ b/application/config/locales/controllers/en.yml
@@ -7,8 +7,9 @@ en:
     file_cancellation_update_error: "Download cancelled: %{filename}, but status update failed. Try again"
     file_cancellation_success: "Download cancelled for file: %{filename}"
     file_deletion_success: "Download file deleted: %{filename}"
-    file_retry_success: "File has been moved back to the pending queue and will be downloaded again."
+    file_retry_success: "File has been moved back to the pending queue and will be downloaded again"
     file_retry_error: "Could not move file back to the pending queue"
+    file_retry_invalid: "File with status %{status} cannot be moved back to the pending queue"
   file_browser:
     directory_forbidden: "You do not have permission to access this directory."
   projects:
@@ -71,6 +72,7 @@ en:
     retry:
       file_retry_success: "File has been moved back to the pending queue and will be uploaded again."
       file_retry_error: "Could not move file back to the pending queue"
+      file_retry_invalid: "File with status %{status} cannot be moved back to the pending queue"
   explore:
     show:
       message_processor_error: "Error processing request for repository: %{connector_type} type: %{object_type} with id: %{object_id}"

--- a/application/config/locales/events/en.yml
+++ b/application/config/locales/events/en.yml
@@ -16,6 +16,7 @@ en:
       error_checksum_verification_message: "Checksum verification failed: file may be corrupted or incomplete"
       cancel_completed: "Cancel request processed (%{status})"
       retry_request: "Retry: file moved back to pending queue"
+      deleted: "Download file deleted: %{filename}"
     upload_file:
       started: "Upload service - Upload started"
       finished: "Upload service - Upload processing completed (%{status})"
@@ -24,3 +25,4 @@ en:
       error_checksum_verification_message: "Checksum verification failed: file may be corrupted or incomplete"
       cancel_completed: "Cancel request processed (%{status})"
       retry_request: "Retry: file moved back to pending queue"
+      deleted: "Upload file deleted: %{filename}"

--- a/application/config/locales/events/en.yml
+++ b/application/config/locales/events/en.yml
@@ -15,6 +15,7 @@ en:
       error_checksum_verification: "Download failure - MD5 validation failed (%{status})"
       error_checksum_verification_message: "Checksum verification failed: file may be corrupted or incomplete"
       cancel_completed: "Cancel request processed (%{status})"
+      retry_request: "Retry: file moved back to pending queue"
     upload_file:
       started: "Upload service - Upload started"
       finished: "Upload service - Upload processing completed (%{status})"
@@ -22,3 +23,4 @@ en:
       error_checksum_verification: "Upload failure - MD5 validation failed (%{status})"
       error_checksum_verification_message: "Checksum verification failed: file may be corrupted or incomplete"
       cancel_completed: "Cancel request processed (%{status})"
+      retry_request: "Retry: file moved back to pending queue"

--- a/application/config/locales/views/en.yml
+++ b/application/config/locales/views/en.yml
@@ -182,6 +182,7 @@ en:
         modal_delete_confirmation_title: "Delete Upload Bundle"
         modal_delete_confirmation_content: "This will remove the upload bundle from the app. Files on disk and any already uploaded files will remain unchanged. To upload again, you’ll need to create a new bundle."
       upload_files:
+        button_retry_upload_title: "Retry Upload"
         button_delete_file_title: "Delete File"
         button_view_events_title: "View File Events"
         button_view_events_label: "View Events"
@@ -280,6 +281,7 @@ en:
     files:
       button_browse_file_a11y_text: "Browse file %{filename}"
       button_browse_file_title: "Browse file"
+      button_retry_upload_title: "Retry upload"
       button_cancel_upload_title: "Cancel upload"
       button_view_events_title: "View File Events"
       button_view_events_label: "View Events"

--- a/application/config/routes.rb
+++ b/application/config/routes.rb
@@ -15,6 +15,7 @@ Rails.application.routes.draw do
     # post /projects/:project_id/downloads/files/:id/cancel => cancel download file
     resources :download_files, path: 'downloads/files', only: [:destroy, :update] do
       post :cancel, on: :member
+      post :retry, on: :member
     end
 
     # post /projects/:project_id/uploads => create new upload batch
@@ -33,6 +34,7 @@ Rails.application.routes.draw do
       # post /projects/:project_id/uploads/:upload_bundle_id/files/:id/cancel => cancel upload_file
       resources :upload_files, path: 'files', only: [ :create, :index, :destroy ] do
         post :cancel, on: :member
+        post :retry, on: :member
       end
     end
 

--- a/application/config/routes.rb
+++ b/application/config/routes.rb
@@ -13,7 +13,8 @@ Rails.application.routes.draw do
 
     # delete /projects/:project_id/downloads/files/:id => delete download file
     # post /projects/:project_id/downloads/files/:id/cancel => cancel download file
-    resources :download_files, path: 'downloads/files', only: [:destroy, :update] do
+    # post /projects/:project_id/downloads/files/:id/retry => retry download file
+    resources :download_files, path: 'downloads/files', only: [:destroy] do
       post :cancel, on: :member
       post :retry, on: :member
     end
@@ -32,6 +33,7 @@ Rails.application.routes.draw do
       # get /projects/:project_id/uploads/:upload_bundle_id/files => gets upload_files from a collection
       # delete /projects/:project_id/uploads/:upload_bundle_id/files/:id => delete upload_file
       # post /projects/:project_id/uploads/:upload_bundle_id/files/:id/cancel => cancel upload_file
+      # post /projects/:project_id/uploads/:upload_bundle_id/files/:id/retry => retry upload_file
       resources :upload_files, path: 'files', only: [ :create, :index, :destroy ] do
         post :cancel, on: :member
         post :retry, on: :member

--- a/application/test/controllers/download_files_controller_test.rb
+++ b/application/test/controllers/download_files_controller_test.rb
@@ -67,7 +67,7 @@ class DownloadFilesControllerTest < ActionDispatch::IntegrationTest
     DownloadFilesController.any_instance.expects(:log_download_file_event).with(
       @file,
       message: 'events.download_file.cancel_completed',
-      metadata: { filename: 'filename_test', previous_status: 'success' }
+      metadata: { previous_status: 'success' }
     )
 
     post cancel_project_download_file_url(project_id: @project_id, id: @file_id)
@@ -103,6 +103,10 @@ class DownloadFilesControllerTest < ActionDispatch::IntegrationTest
     @file.stubs(:filename).returns('file.zip')
     @file.expects(:destroy)
     DownloadFile.stubs(:find).with(@project_id, @file_id).returns(@file)
+    DownloadFilesController.any_instance.expects(:log_download_file_event).with(
+      @file,
+      message: 'events.download_file.deleted'
+    )
 
     delete project_download_file_url(project_id: @project_id, id: @file_id)
     assert_redirected_to root_path

--- a/application/test/controllers/upload_files_controller_test.rb
+++ b/application/test/controllers/upload_files_controller_test.rb
@@ -10,8 +10,8 @@ class UploadFilesControllerTest < ActionDispatch::IntegrationTest
   end
 
   test 'index should return success' do
-    collection = create_upload_bundle(create_project)
-    UploadBundle.stubs(:find).returns(collection)
+    upload_bundle = create_upload_bundle(create_project)
+    UploadBundle.stubs(:find).returns(upload_bundle)
 
     get project_upload_bundle_upload_files_url(@project_id, @upload_bundle_id)
 
@@ -25,7 +25,9 @@ class UploadFilesControllerTest < ActionDispatch::IntegrationTest
       path: @test_path
     }
 
-    assert_response :not_found
+    assert_redirected_to root_path
+    follow_redirect!
+    assert_match 'Upload bundle not found', flash[:alert]
   end
 
   test 'create should return bad request if file is invalid' do
@@ -44,7 +46,10 @@ class UploadFilesControllerTest < ActionDispatch::IntegrationTest
   end
 
   test 'create should create and return ok if files are valid' do
-    UploadBundle.stubs(:find).returns(mock)
+    upload_bundle = create_upload_bundle(create_project)
+    upload_bundle.id = @upload_bundle_id
+    upload_bundle.project_id = @project_id
+    UploadBundle.stubs(:find).returns(upload_bundle)
 
     UploadFilesController.any_instance.stubs(:list_files)
                          .returns([OpenStruct.new(fullpath: @test_path, filename: 'valid.txt', size: 456)])
@@ -71,10 +76,11 @@ class UploadFilesControllerTest < ActionDispatch::IntegrationTest
   end
 
   test 'delete should destroy upload file and redirect when not uploading' do
-    file = mock
-    file.stubs(:nil?).returns(false)
-    file.stubs(:status).returns(FileStatus::PENDING)
-    file.stubs(:filename).returns('delete.txt')
+    file = UploadFile.new.tap do |file|
+      file.id = @file_id
+      file.filename = 'delete.txt'
+      file.status = FileStatus::PENDING
+    end
     file.expects(:destroy)
 
     UploadFile.stubs(:find).with(@project_id, @upload_bundle_id, @file_id).returns(file)
@@ -87,10 +93,11 @@ class UploadFilesControllerTest < ActionDispatch::IntegrationTest
   end
 
   test 'delete should return error when file is uploading' do
-    file = mock
-    file.stubs(:nil?).returns(false)
-    file.stubs(:status).returns(FileStatus::UPLOADING)
-    file.stubs(:filename).returns('delete.txt')
+    file = UploadFile.new.tap do |file|
+      file.id = @file_id
+      file.filename = 'delete.txt'
+      file.status = FileStatus::UPLOADING
+    end
     file.expects(:destroy).never
 
     UploadFile.stubs(:find).with(@project_id, @upload_bundle_id, @file_id).returns(file)
@@ -108,13 +115,18 @@ class UploadFilesControllerTest < ActionDispatch::IntegrationTest
     post cancel_project_upload_bundle_upload_file_url(@project_id, @upload_bundle_id, @file_id)
     assert_redirected_to root_path
     follow_redirect!
-    assert_match 'file not found', flash[:alert]
+    assert_match @file_id, flash[:alert]
+    assert_match 'not found', flash[:alert]
   end
 
   test 'cancel should cancel uploading file and return no content' do
-    file = UploadFile.new
-    file.stubs(:status).returns(FileStatus::UPLOADING)
-    file.stubs(:filename).returns('cancel.txt')
+    file = UploadFile.new.tap do |file|
+      file.id = @file_id
+      file.project_id = @project_id
+      file.upload_bundle_id = @upload_bundle_id
+      file.filename = 'cancel.txt'
+      file.status = FileStatus::UPLOADING
+    end
     file.expects(:update).with(status: FileStatus::CANCELLED).returns(true)
 
     UploadFile.stubs(:find).returns(file)
@@ -137,9 +149,13 @@ class UploadFilesControllerTest < ActionDispatch::IntegrationTest
   end
 
   test 'cancel should log event when file is not uploading' do
-    file = UploadFile.new
-    file.stubs(:status).returns(FileStatus::SUCCESS)
-    file.stubs(:filename).returns('done.txt')
+    file = UploadFile.new.tap do |file|
+      file.id = @file_id
+      file.project_id = @project_id
+      file.upload_bundle_id = @upload_bundle_id
+      file.filename = 'done.txt'
+      file.status = FileStatus::SUCCESS
+    end
     file.expects(:update).with(status: FileStatus::CANCELLED).returns(true)
 
     UploadFile.stubs(:find).returns(file)
@@ -155,5 +171,59 @@ class UploadFilesControllerTest < ActionDispatch::IntegrationTest
     follow_redirect!
     assert_match 'Upload cancelled', flash[:notice]
     assert_match 'done.txt', flash[:notice]
+  end
+
+  test 'retry should redirect with error message when file is missing' do
+    UploadFile.stubs(:find).returns(nil)
+
+    post retry_project_upload_bundle_upload_file_url(@project_id, @upload_bundle_id, @file_id)
+    assert_redirected_to root_path
+    follow_redirect!
+    assert_match @file_id, flash[:alert]
+    assert_match 'not found', flash[:alert]
+  end
+
+  test 'retry should update file status to pending and redirect with success message' do
+    file = UploadFile.new.tap do |file|
+      file.id = @file_id
+      file.project_id = @project_id
+      file.upload_bundle_id = @upload_bundle_id
+      file.filename = 'retry.txt'
+      file.status = FileStatus::ERROR
+    end
+    file.expects(:update).with(status: FileStatus::PENDING).returns(true)
+
+    UploadFile.stubs(:find).returns(file)
+
+    UploadFilesController.any_instance.expects(:log_upload_file_event).with(
+      file,
+      message: 'events.upload_file.retry_request',
+      metadata: { filename: 'retry.txt', previous_status: FileStatus::ERROR }
+    )
+
+    post retry_project_upload_bundle_upload_file_url(@project_id, @upload_bundle_id, @file_id)
+    assert_redirected_to root_path
+    follow_redirect!
+    assert_includes flash[:notice], 'File has been moved back to the pending queue and will be uploaded again'
+  end
+
+  test 'retry should redirect with error message when update fails' do
+    file = UploadFile.new.tap do |file|
+      file.id = @file_id
+      file.project_id = @project_id
+      file.upload_bundle_id = @upload_bundle_id
+      file.filename = 'retry_fail.txt'
+      file.status = FileStatus::ERROR
+    end
+    file.expects(:update).with(status: FileStatus::PENDING).returns(false)
+
+    UploadFile.stubs(:find).returns(file)
+
+    UploadFilesController.any_instance.expects(:log_upload_file_event).never
+
+    post retry_project_upload_bundle_upload_file_url(@project_id, @upload_bundle_id, @file_id)
+    assert_redirected_to root_path
+    follow_redirect!
+    assert_includes flash[:alert], 'Could not move file back to the pending queue'
   end
 end


### PR DESCRIPTION
## Description
Added support to retry cancelled or error uploads.
UploadFile is update with the status of pending.

Works in the same way as downloading.

## Related Issue
Fixes #510 

## Testing
- [x] Added/updated tests
- [x] All tests pass locally
- [x] Tested manually (describe how)

## Documentation
- [ ] Updated relevant documentation
- [x] No documentation changes needed