### PR TITLE
Updating github actions dependabot configuration to only alert for gi…

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,24 +1,24 @@
 version: 2
 updates:
   # Ruby gems using Bundler
-  - package-ecosystem: bundler
-    directory: /application
-    schedule:
-      interval: weekly
-    open-pull-requests-limit: 5
-    commit-message:
-      prefix: bundler
-    labels: ['epic.dependencies']
+  # - package-ecosystem: bundler
+  #   directory: /application
+  #   schedule:
+  #     interval: weekly
+  #   open-pull-requests-limit: 5
+  #   commit-message:
+  #     prefix: bundler
+  #   labels: ['epic.dependencies']
 
-  # JavaScript dependencies using npm
-  - package-ecosystem: npm
-    directory: /application
-    schedule:
-      interval: weekly
-    open-pull-requests-limit: 5
-    commit-message:
-      prefix: npm
-    labels: ['epic.dependencies']
+  # # JavaScript dependencies using npm
+  # - package-ecosystem: npm
+  #   directory: /application
+  #   schedule:
+  #     interval: weekly
+  #   open-pull-requests-limit: 5
+  #   commit-message:
+  #     prefix: npm
+  #   labels: ['epic.dependencies']
 
   # GitHub Actions
   - package-ecosystem: github-actions
@@ -27,4 +27,4 @@ updates:
       interval: weekly
     commit-message:
       prefix: actions
-    labels: ['epic.dependencies']
+    labels: ["epic.dependencies"]


### PR DESCRIPTION
## Description
This PR updates GitHub actions dependabot configuration to only alert on GitHub actions updates

## Related Issue


## Testing
- n/a. I did validate YAML using yq

## Documentation
- No documentation updates required