### PR TITLE
fix: strip spaces from URLs in upload bundle creation

### DIFF
--- a/application/app/controllers/repository_settings_controller.rb
+++ b/application/app/controllers/repository_settings_controller.rb
@@ -20,7 +20,7 @@ class RepositorySettingsController < ApplicationController
   end
 
   def update
-    repo_url = params[:repo_url]
+    repo_url = params[:repo_url].to_s.strip
     repo = ::Configuration.repo_db.get(repo_url)
     unless repo
       redirect_to repository_settings_path, alert: t('.message_not_found', domain: repo_url) and return

--- a/application/app/controllers/upload_bundles_connector_controller.rb
+++ b/application/app/controllers/upload_bundles_connector_controller.rb
@@ -11,7 +11,7 @@ class UploadBundlesConnectorController < ApplicationController
       return
     end
 
-    repo_url = params[:remote_repo_url]
+    repo_url = params[:remote_repo_url].to_s.strip
     repo_resolver = ::Configuration.repo_resolver_service
     url_resolution = repo_resolver.resolve(repo_url)
     log_info('Remote Repo resolution', { repo_url: repo_url, type: url_resolution.type })


### PR DESCRIPTION
## Description
Strip spaces from URLs in upload bundle creation so that they are recognized, same as other URL inputs.

## Related Issue
Fixes #538

## Testing
- [x] Tested manually (describe how) -- ran in local dev, created project, created upload bundle, entered URL successfully with leading and trailing spaces.

## Documentation
- [x] No documentation changes needed