### PR TITLE
fix: chomp DEPLOYMENT string before display (#546)

### DIFF
--- a/application/app/views/layouts/application.html.erb
+++ b/application/app/views/layouts/application.html.erb
@@ -4,7 +4,7 @@
     <title><%= content_for(:title) || "OnDemand Loop" %></title>
     <meta name="viewport" content="width=device-width,initial-scale=1">
     <meta name="apple-mobile-web-app-capable" content="yes">
-    <meta name="deployment" content="<%= Configuration.deployment %>">
+    <meta name="deployment" content="<%= Configuration.deployment.to_s.chomp %>">
     <%= csrf_meta_tags %>
     <%= csp_meta_tag %>
 


### PR DESCRIPTION
## Description
Chomps the DEPLOYMENT string before display so we don't end up with a newline embedded inside a double-quoted HTML element attribute value.

## Related Issue
Fixes #546 

## Testing
- [x] Tested manually -- copied DEPLOYMENT file from QA to dev, observed embedded newline, changed code, observed no newline

## Documentation
- [x] No documentation changes needed